### PR TITLE
feat: add support for setup files in jest

### DIFF
--- a/apps/playground/jest.config.js
+++ b/apps/playground/jest.config.js
@@ -5,6 +5,8 @@ module.exports = {
       testMatch: [
         '<rootDir>/src/__tests__/**/*.(test|spec|harness).(js|jsx|ts|tsx)',
       ],
+      setupFiles: ['./src/setupFile.ts'],
+      setupFilesAfterEnv: ['./src/setupFileAfterEnv.ts'],
     },
   ],
 };

--- a/apps/playground/src/__tests__/setup-files.harness.ts
+++ b/apps/playground/src/__tests__/setup-files.harness.ts
@@ -1,0 +1,11 @@
+import { describe, test, expect } from 'react-native-harness';
+
+describe('Setup files', () => {
+  test('should execute setup file', () => {
+    expect(global.SETUP_FILE_EXECUTED).toBe(true);
+  });
+
+  test('should execute setup file after env', () => {
+    expect(global.SETUP_FILE_EXECUTED_AFTER_ENV).toBe(true);
+  });
+});

--- a/apps/playground/src/setupFile.ts
+++ b/apps/playground/src/setupFile.ts
@@ -1,0 +1,6 @@
+declare global {
+  var SETUP_FILE_EXECUTED: boolean;
+}
+
+global.SETUP_FILE_EXECUTED = true;
+export {};

--- a/apps/playground/src/setupFileAfterEnv.ts
+++ b/apps/playground/src/setupFileAfterEnv.ts
@@ -1,0 +1,6 @@
+declare global {
+  var SETUP_FILE_EXECUTED_AFTER_ENV: boolean;
+}
+
+global.SETUP_FILE_EXECUTED_AFTER_ENV = true;
+export {};

--- a/packages/bridge/src/shared.ts
+++ b/packages/bridge/src/shared.ts
@@ -31,6 +31,9 @@ export type {
   ModuleBundlingStartedEvent,
   ModuleBundlingFinishedEvent,
   ModuleBundlingFailedEvent,
+  SetupFileBundlingStartedEvent,
+  SetupFileBundlingFinishedEvent,
+  SetupFileBundlingFailedEvent,
   BundlerEvents,
 } from './shared/bundler.js';
 
@@ -54,6 +57,8 @@ export type BridgeEventsMap = {
 
 export type TestExecutionOptions = {
   testNamePattern?: string;
+  setupFiles?: string[];
+  setupFilesAfterEnv?: string[];
 };
 
 export type BridgeClientFunctions = {

--- a/packages/bridge/src/shared/bundler.ts
+++ b/packages/bridge/src/shared/bundler.ts
@@ -16,7 +16,31 @@ export type ModuleBundlingFailedEvent = {
   error: string;
 };
 
+export type SetupFileBundlingStartedEvent = {
+  type: 'setup-file-bundling-started';
+  file: string;
+  setupType: 'setupFiles' | 'setupFilesAfterEnv';
+};
+
+export type SetupFileBundlingFinishedEvent = {
+  type: 'setup-file-bundling-finished';
+  file: string;
+  setupType: 'setupFiles' | 'setupFilesAfterEnv';
+  duration: number;
+};
+
+export type SetupFileBundlingFailedEvent = {
+  type: 'setup-file-bundling-failed';
+  file: string;
+  setupType: 'setupFiles' | 'setupFilesAfterEnv';
+  duration: number;
+  error: string;
+};
+
 export type BundlerEvents =
   | ModuleBundlingStartedEvent
   | ModuleBundlingFinishedEvent
-  | ModuleBundlingFailedEvent;
+  | ModuleBundlingFailedEvent
+  | SetupFileBundlingStartedEvent
+  | SetupFileBundlingFinishedEvent
+  | SetupFileBundlingFailedEvent;

--- a/packages/jest/src/run.ts
+++ b/packages/jest/src/run.ts
@@ -59,13 +59,25 @@ export type RunHarnessTestFile = (options: {
 export const runHarnessTestFile: RunHarnessTestFile = async ({
   testPath,
   globalConfig,
+  projectConfig,
   harness,
 }) => {
   const start = Date.now();
   const relativeTestPath = path.relative(globalConfig.rootDir, testPath);
+
+  // Extract setup files from Jest config and convert to relative paths
+  const setupFiles = projectConfig.setupFiles?.map((setupFile) =>
+    path.relative(globalConfig.rootDir, setupFile)
+  );
+  const setupFilesAfterEnv = projectConfig.setupFilesAfterEnv?.map(
+    (setupFile) => path.relative(globalConfig.rootDir, setupFile)
+  );
+
   const client = harness.bridge.rpc.clients.at(-1)!;
   const results = await client.runTests(relativeTestPath, {
     testNamePattern: globalConfig.testNamePattern,
+    setupFiles,
+    setupFilesAfterEnv,
   });
   const end = Date.now();
 


### PR DESCRIPTION
This pull request adds support for Jest’s setupFiles and setupFilesAfterEnv features. Both are executed before the test files - with setupFiles running first, followed by setupFilesAfterEnv. These files are bundled by Metro, just like the test files, so you can freely use TypeScript and import modules.