### PR TITLE
docs: fix babel preset name in quick-start guide

### DIFF
--- a/website/src/docs/getting-started/quick-start.mdx
+++ b/website/src/docs/getting-started/quick-start.mdx
@@ -65,7 +65,7 @@ Add the required preset to `babel.config.js`. This is needed for module mocking 
 
 ```javascript
 module.exports = {
-  presets: ['module:@react-native/babel-preset', 'react-native-harness/babel'],
+  presets: ['module:@react-native/babel-preset', 'react-native-harness/babel-preset'],
   // Your existing Babel config
 };
 ```


### PR DESCRIPTION
## Summary
fixes bable import in docs as in [package.json ](https://github.com/callstackincubator/react-native-harness/blob/cae7174923baaf03fd2f48dce9df7762206b6a28/packages/react-native-harness/package.json#L25C5-L25C21)