### PR TITLE
feat: support coverage

### DIFF
--- a/apps/playground/jest.config.js
+++ b/apps/playground/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
       setupFilesAfterEnv: ['./src/setupFileAfterEnv.ts'],
     },
   ],
+  collectCoverageFrom: ['./src/**/*.(ts|tsx)'],
 };

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -15,7 +15,8 @@
     }
   },
   "dependencies": {
-    "@babel/plugin-transform-class-static-block": "^7.27.1"
+    "@babel/plugin-transform-class-static-block": "^7.27.1",
+    "babel-plugin-istanbul": "^7.0.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.22.0"

--- a/packages/babel-preset/src/preset.ts
+++ b/packages/babel-preset/src/preset.ts
@@ -3,7 +3,8 @@ import resolveWeakPlugin from './resolve-weak-plugin';
 export const rnHarnessPlugins = [
   '@babel/plugin-transform-class-static-block',
   resolveWeakPlugin,
-];
+  process.env.RN_HARNESS_COLLECT_COVERAGE ? 'babel-plugin-istanbul' : null,
+].filter((plugin): plugin is string => plugin !== null);
 
 export const rnHarnessPreset = () => {
   if (!process.env.RN_HARNESS) {

--- a/packages/bridge/src/shared/test-runner.ts
+++ b/packages/bridge/src/shared/test-runner.ts
@@ -80,4 +80,5 @@ export type TestSuiteResult = {
   status: TestResultStatus;
   error?: SerializedError;
   duration: number;
+  coverage?: unknown;
 };

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -66,6 +66,13 @@ export default class JestHarness implements CallbackTestRunnerInterface {
     const { config: harnessConfig } = await getConfig(projectRoot);
     const cliArgs = getAdditionalCliArgs();
     const selectedRunner = getHarnessRunner(harnessConfig, cliArgs);
+
+    if (this.#globalConfig.collectCoverage) {
+      // This is going to be used by @react-native-harness/babel-preset
+      // to enable instrumentation of test files.
+      process.env.RN_HARNESS_COLLECT_COVERAGE = 'true';
+    }
+
     const harness = await getHarness(selectedRunner);
 
     try {

--- a/packages/jest/src/run.ts
+++ b/packages/jest/src/run.ts
@@ -111,5 +111,6 @@ export const runHarnessTestFile: RunHarnessTestFile = async ({
     errorMessage,
     tests,
     jestTestPath: testPath,
+    coverage: results.coverage as JestTestResult['coverage'],
   });
 };

--- a/packages/runtime/src/runner/factory.ts
+++ b/packages/runtime/src/runner/factory.ts
@@ -9,10 +9,17 @@ export const getTestRunner = (): TestRunner => {
   return {
     events,
     run: async (testSuite, testFilePath) => {
-      return runSuite(testSuite, {
+      const result = await runSuite(testSuite, {
         events,
         testFilePath,
       });
+
+      // If coverage is enabled, there will be a global variable called __coverage__
+      if ('__coverage__' in global && !!global.__coverage__) {
+        result.coverage = global.__coverage__;
+      }
+
+      return result;
     },
     dispose: () => {
       events.clearAllListeners();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@babel/plugin-transform-class-static-block':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.27.4)
+      babel-plugin-istanbul:
+        specifier: ^7.0.1
+        version: 7.0.1
     devDependencies:
       '@babel/core':
         specifier: ^7.22.0
@@ -3532,10 +3535,6 @@ packages:
   babel-plugin-istanbul@6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
-
-  babel-plugin-istanbul@7.0.0:
-    resolution: {integrity: sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==}
-    engines: {node: '>=12'}
 
   babel-plugin-istanbul@7.0.1:
     resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
@@ -10147,7 +10146,7 @@ snapshots:
       '@babel/core': 7.27.4
       '@jest/types': 30.0.5
       '@jridgewell/trace-mapping': 0.3.25
-      babel-plugin-istanbul: 7.0.0
+      babel-plugin-istanbul: 7.0.1
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -12851,7 +12850,7 @@ snapshots:
       '@babel/core': 7.27.4
       '@jest/transform': 30.0.5
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 7.0.0
+      babel-plugin-istanbul: 7.0.1
       babel-preset-jest: 30.0.1(@babel/core@7.27.4)
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -12887,16 +12886,6 @@ snapshots:
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
-      test-exclude: 6.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-istanbul@7.0.0:
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 6.0.3
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
This pull request adds support for code coverage reporting in the Jest integration. You can now use the --coverage parameter when running Jest with Harness to collect data on how much of your code is covered by your test suites.