### PR TITLE
feat: throw when jest globals are used

### DIFF
--- a/apps/playground/src/__tests__/jest-throw.harness.ts
+++ b/apps/playground/src/__tests__/jest-throw.harness.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'react-native-harness';
+
+describe('Jest globals warning', () => {
+  it('should throw when accessing jest global', () => {
+    expect(() => {
+      // @ts-expect-error - jest is not available in Harness tests
+      jest.fn();
+    }).toThrow('Jest globals are not available in Harness tests');
+  });
+
+  it('should throw when importing @jest/globals', () => {
+    expect(() => require('@jest/globals')).toThrow(
+      "Importing '@jest/globals' is not supported in Harness tests"
+    );
+  });
+});

--- a/packages/metro/src/jest-globals-mock.ts
+++ b/packages/metro/src/jest-globals-mock.ts
@@ -1,0 +1,6 @@
+// Mock module for @jest/globals imports
+// This module throws immediately when imported to warn users about using Jest APIs
+
+throw new Error(
+  "Importing '@jest/globals' is not supported in Harness tests. Import from 'react-native-harness' instead."
+);

--- a/packages/metro/src/resolver.ts
+++ b/packages/metro/src/resolver.ts
@@ -30,6 +30,14 @@ export const getHarnessResolver = (
       };
     }
 
+    // Intercept @jest/globals imports and redirect to mock module
+    if (moduleName === '@jest/globals') {
+      return {
+        type: 'sourceFile',
+        filePath: require.resolve('./jest-globals-mock'),
+      };
+    }
+
     return resolvedModule;
   };
 };

--- a/packages/runtime/assets/moduleSystem.flow.js
+++ b/packages/runtime/assets/moduleSystem.flow.js
@@ -588,11 +588,14 @@ function loadModuleImplementation(
     // keep args in sync with with defineModuleCode in
     // metro/src/Resolver/index.js
     // and metro/src/ModuleGraph/worker.js
+    const capturedRequire = (...args) => global.__r(...args);
+    Object.assign(capturedRequire, global.__r);
+
     factory(
       global,
-      (...args) => global.__r(...args),
-      (...args) => global.__r.importDefault(...args),
-      (...args) => global.__r.importAll(...args),
+      capturedRequire,
+      capturedRequire.importDefault,
+      capturedRequire.importAll,
       moduleObject,
       moduleObject.exports,
       dependencyMap

--- a/packages/runtime/src/initialize.ts
+++ b/packages/runtime/src/initialize.ts
@@ -1,10 +1,14 @@
 import { getDeviceDescriptor } from './client/getDeviceDescriptor.js';
 import { getClient } from './client/index.js';
+import { setupJestMock } from './jest-mock.js';
 
 // Polyfill for EventTarget
 const Shim = require('event-target-shim');
 globalThis.Event = Shim.Event;
 globalThis.EventTarget = Shim.EventTarget;
+
+// Setup jest mock to warn users about using Jest APIs
+setupJestMock();
 
 // Turn off LogBox
 const { LogBox } = require('react-native');
@@ -12,7 +16,8 @@ LogBox.ignoreAllLogs(true);
 
 // Turn off HMR
 const HMRClientModule = require('react-native/Libraries/Utilities/HMRClient');
-const HMRClient = 'default' in HMRClientModule ? HMRClientModule.default : HMRClientModule;
+const HMRClient =
+  'default' in HMRClientModule ? HMRClientModule.default : HMRClientModule;
 
 // Wait for HMRClient to be initialized
 setTimeout(() => {
@@ -22,4 +27,9 @@ setTimeout(() => {
   void getClient().then((client) =>
     client.rpc.reportReady(getDeviceDescriptor())
   );
+});
+
+// Re-throw fatal errors
+ErrorUtils.setGlobalHandler((error) => {
+  throw error;
 });

--- a/packages/runtime/src/jest-mock.ts
+++ b/packages/runtime/src/jest-mock.ts
@@ -1,0 +1,32 @@
+// Mock jest global to warn users about using Jest APIs in Harness tests
+export const setupJestMock = (): void => {
+  function throwError(): never {
+    throw new Error(
+      `Jest globals are not available in Harness tests. Import from 'react-native-harness' instead (e.g., import { harness } from 'react-native-harness'; harness.fn())`
+    );
+  }
+
+  const jestMock = new Proxy(
+    {},
+    {
+      get() {
+        throwError();
+      },
+      set() {
+        throwError();
+      },
+      has() {
+        throwError();
+      },
+      ownKeys() {
+        throwError();
+      },
+    }
+  );
+
+  Object.defineProperty(globalThis, 'jest', {
+    value: jestMock,
+    writable: false,
+    configurable: false,
+  });
+};


### PR DESCRIPTION
Users might forget to replace all instances of the jest global with harness. We should remind them to do so as soon as we detect any usage. This pull request introduces the necessary changes to throw an error whenever the jest global is used or when @jest/globals is imported.