### PR TITLE
feat: re-export jest preset from main package

### DIFF
--- a/apps/playground/jest.config.js
+++ b/apps/playground/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   projects: [
     {
-      preset: '@react-native-harness/jest',
+      preset: 'react-native-harness',
       testMatch: [
         '<rootDir>/src/__tests__/**/*.(test|spec|harness).(js|jsx|ts|tsx)',
       ],

--- a/packages/react-native-harness/package.json
+++ b/packages/react-native-harness/package.json
@@ -28,14 +28,21 @@
       "import": "./dist/babel.js",
       "default": "./dist/babel.js"
     },
-    "./types": "./types/index.d.ts"
+    "./types": "./types/index.d.ts",
+    "./jest-preset": {
+      "development": "./src/jest-preset.ts",
+      "types": "./dist/jest-preset.d.ts",
+      "import": "./dist/jest-preset.js",
+      "default": "./dist/jest-preset.js"
+    }
   },
   "dependencies": {
     "tslib": "^2.3.0",
     "@react-native-harness/runtime": "workspace:*",
     "@react-native-harness/cli": "workspace:*",
     "@react-native-harness/metro": "workspace:*",
-    "@react-native-harness/babel-preset": "workspace:*"
+    "@react-native-harness/babel-preset": "workspace:*",
+    "@react-native-harness/jest": "workspace:*"
   },
   "license": "MIT"
 }

--- a/packages/react-native-harness/src/jest-preset.ts
+++ b/packages/react-native-harness/src/jest-preset.ts
@@ -1,0 +1,1 @@
+export { default } from '@react-native-harness/jest/jest-preset';

--- a/packages/react-native-harness/tsconfig.json
+++ b/packages/react-native-harness/tsconfig.json
@@ -4,6 +4,9 @@
   "include": [],
   "references": [
     {
+      "path": "../jest"
+    },
+    {
       "path": "../babel-preset"
     },
     {

--- a/packages/react-native-harness/tsconfig.lib.json
+++ b/packages/react-native-harness/tsconfig.lib.json
@@ -12,6 +12,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../jest/tsconfig.lib.json"
+    },
+    {
       "path": "../babel-preset/tsconfig.lib.json"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@react-native-harness/cli':
         specifier: workspace:*
         version: link:../cli
+      '@react-native-harness/jest':
+        specifier: workspace:*
+        version: link:../jest
       '@react-native-harness/metro':
         specifier: workspace:*
         version: link:../metro
@@ -11405,7 +11408,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.76.9': {}
 


### PR DESCRIPTION
This pull request re-exports the Jest preset from the main package, making it easier to configure the tool.