### PR TITLE
fix: wrong URL used to bundle tests

### DIFF
--- a/packages/runtime/src/bundler/bundle.ts
+++ b/packages/runtime/src/bundler/bundle.ts
@@ -8,7 +8,6 @@ const getModuleUrl = (fileName: string): string => {
   const urlSearchParams = new URLSearchParams({
     modulesOnly: 'true',
     platform: Platform.OS,
-    'resolver.isHarness': 'true',
   });
 
   return `${devServerUrl}${bundleName}?${urlSearchParams.toString()}`;


### PR DESCRIPTION
The behavior of double slashes (//) changed in some version of React Native or Metro. What used to work before is now causing the bundling process to fail. This pull request ensures that there is only one slash present in the URL.