### PR TITLE
feat: guard against augmenting the Metro config twice

### DIFF
--- a/packages/bundler-metro/src/factory.ts
+++ b/packages/bundler-metro/src/factory.ts
@@ -52,7 +52,7 @@ export const getMetroInstance = async (
     port: METRO_PORT,
     projectRoot,
   });
-  const config = await withRnHarness(projectMetroConfig)();
+  const config = await withRnHarness(projectMetroConfig, true)();
   const reporter = withReporter(config);
 
   abortSignal.throwIfAborted();

--- a/packages/metro/src/withRnHarness.ts
+++ b/packages/metro/src/withRnHarness.ts
@@ -11,10 +11,17 @@ const INTERNAL_CALLSITES_REGEX =
   /(^|[\\/])(node_modules[/\\]@react-native-harness)([\\/]|$)/;
 
 export const withRnHarness = <T extends MetroConfig>(
-  config: T | Promise<T>
+  config: T | Promise<T>,
+  isInvokedByHarness = false
 ): (() => Promise<T>) => {
   // This is a workaround for a regression in Metro 0.83, when promises are not handled correctly.
   return async () => {
+    // If the function is not invoked by the Harness, return the config as is.
+    // We'll remove it in the next major version.
+    if (!isInvokedByHarness) {
+      return config;
+    }
+
     const metroConfig = await config;
     const { config: harnessConfig } = await getConfig(process.cwd());
 


### PR DESCRIPTION
You no longer need to wrap your Metro config with the withRnHarness function because Harness handles this internally. As a result, manually calling withRnHarness should have no effect.