### PR TITLE
fix(runtime): add Object.hasOwn polyfill for Hermes compatibility

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,5 @@
+// Polyfills must be imported first to ensure compatibility with Hermes
+import './polyfills.js';
 import './globals.d.ts';
 
 export { UI as ReactNativeHarness } from './ui/index.js';

--- a/packages/runtime/src/polyfills.ts
+++ b/packages/runtime/src/polyfills.ts
@@ -1,0 +1,16 @@
+/**
+ * Polyfills for Hermes JavaScript engine compatibility.
+ *
+ * Hermes (React Native's default JS engine) doesn't support all ES2022+ features.
+ * This file provides polyfills for features used by harness dependencies.
+ */
+
+/**
+ * Object.hasOwn (ES2022)
+ * Used by @vitest/expect v4.x for property checking.
+ * @see https://github.com/facebook/hermes/issues/1875
+ */
+if (typeof Object.hasOwn !== 'function') {
+  Object.hasOwn = (obj: object, prop: PropertyKey): boolean =>
+    Object.prototype.hasOwnProperty.call(obj, prop);
+}


### PR DESCRIPTION
## Description

Adds `Object.hasOwn` polyfill to the runtime package for Hermes compatibility.

Hermes (React Native's default JS engine) doesn't support `Object.hasOwn` (ES2022). This causes runtime errors when `@vitest/expect` v4.x initializes:

```
Object.hasOwn is not a function. (In 'Object.hasOwn(globalThis, MATCHERS_OBJECT)', 'Object.hasOwn' is undefined)
```

## Related Issue

Fixes #51

## Context

The error originates from `@vitest/expect/dist/index.js:674`:
```js
if (!Object.hasOwn(globalThis, MATCHERS_OBJECT)) {
```

Since react-native-harness targets React Native (which uses Hermes by default) and depends on `@vitest/expect` v4.x, the polyfill belongs in the harness runtime rather than requiring every consumer to add it.

The polyfill is minimal and standards-compliant:
```ts
if (typeof Object.hasOwn !== 'function') {
  Object.hasOwn = (obj: object, prop: PropertyKey): boolean =>
    Object.prototype.hasOwnProperty.call(obj, prop);
}
```

## Testing

- Tested on Android emulator with Hermes enabled
- Harness tests pass after adding this polyfill

## References

- Hermes tracking issue: https://github.com/facebook/hermes/issues/1875
- MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn