### PR TITLE
fix: build runtime overlay against React Native 0.85+

### DIFF
--- a/packages/runtime/src/render/TestComponentOverlay.tsx
+++ b/packages/runtime/src/render/TestComponentOverlay.tsx
@@ -52,7 +52,11 @@ export const TestComponentOverlay = (): React.ReactElement | null => {
   };
 
   return (
-    <View key={key} style={styles.overlay} onLayout={handleLayout}>
+    <View
+      key={key}
+      style={[StyleSheet.absoluteFill, styles.overlay]}
+      onLayout={handleLayout}
+    >
       <ErrorBoundary>{element}</ErrorBoundary>
     </View>
   );
@@ -60,7 +64,6 @@ export const TestComponentOverlay = (): React.ReactElement | null => {
 
 const styles = StyleSheet.create({
   overlay: {
-    ...StyleSheet.absoluteFillObject,
     backgroundColor: '#0a1628',
     zIndex: 1000,
   },


### PR DESCRIPTION
## Context

In react-native 0.85 `StyleSheet.absoluteFillObject` was removed: https://reactnative.dev/blog/2026/04/07/react-native-0.85#stylesheetabsolutefillobject-removed

## Summary
- replace `StyleSheet.absoluteFillObject` usage in the runtime test overlay with `StyleSheet.absoluteFill`
- unblock building `@react-native-harness/runtime` against React Native 0.85+, where the published `StyleSheet` type surface exposes `absoluteFill` but no longer exposes `absoluteFillObject`
