### PR TITLE
fix: harden Harness against Expo SDK

### DIFF
--- a/.changeset/expo-entry-runtime-compat.md
+++ b/.changeset/expo-entry-runtime-compat.md
@@ -1,0 +1,7 @@
+---
+'@react-native-harness/bundler-metro': patch
+'@react-native-harness/runtime': patch
+'@react-native-harness/bridge': patch
+---
+
+Fix Expo app startup by resolving package-style entry points before hijacking Metro, recognizing Expo's virtual Metro entry bundle during readiness detection, and making the runtime bridge initialization compatible with Expo's Metro runtime and React Compiler.

--- a/packages/bridge/src/client.ts
+++ b/packages/bridge/src/client.ts
@@ -11,13 +11,33 @@ export type BridgeClient = {
 
 const getBridgeClient = async (
   url: string,
-  handlers: BridgeClientFunctions
+  handlers: BridgeClientFunctions,
 ): Promise<BridgeClient> => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
     ws.binaryType = 'arraybuffer';
+    let settled = false;
+
+    const cleanup = () => {
+      ws.removeEventListener('open', handleOpen);
+      ws.removeEventListener('error', handleError);
+      ws.removeEventListener('close', handleClose);
+    };
+
+    const rejectConnection = (message: string) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      reject(new Error(message));
+    };
 
     const handleOpen = () => {
+      settled = true;
+      cleanup();
+
       const rpc = createBirpc<BridgeServerFunctions, BridgeClientFunctions>(
         handlers,
         {
@@ -31,7 +51,7 @@ const getBridgeClient = async (
           },
           serialize,
           deserialize,
-        }
+        },
       );
 
       const client: BridgeClient = {
@@ -48,7 +68,26 @@ const getBridgeClient = async (
       resolve(client);
     };
 
-    ws.addEventListener('open', handleOpen, { once: true });
+    const handleError = (event: Event & { message?: string }) => {
+      const reason =
+        typeof event.message === 'string' && event.message.length > 0
+          ? `: ${event.message}`
+          : '';
+
+      rejectConnection(
+        `Failed to connect to the Harness bridge at ${url}${reason}`,
+      );
+    };
+
+    const handleClose = (event: CloseEvent) => {
+      rejectConnection(
+        `Harness bridge connection to ${url} closed before it became ready (code ${event.code}${event.reason ? `, reason: ${event.reason}` : ''})`,
+      );
+    };
+
+    ws.addEventListener('open', handleOpen);
+    ws.addEventListener('error', handleError);
+    ws.addEventListener('close', handleClose);
   });
 };
 

--- a/packages/bundler-metro/src/__tests__/bundle-request-middleware.test.ts
+++ b/packages/bundler-metro/src/__tests__/bundle-request-middleware.test.ts
@@ -24,7 +24,7 @@ const createReporter = () => {
 
 const createProjectRoot = () => {
   const projectRoot = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'rn-harness-bundle-request-')
+    path.join(os.tmpdir(), 'rn-harness-bundle-request-'),
   );
   tempDirs.push(projectRoot);
   fs.writeFileSync(path.join(projectRoot, 'index.js'), 'module.exports = {};');
@@ -50,7 +50,7 @@ describe('bundle request observer middleware', () => {
     const middleware = getBundleRequestObserverMiddleware(
       createProjectRoot(),
       createHarnessConfig(),
-      reporter
+      reporter,
     );
     const next = vi.fn();
 
@@ -60,7 +60,7 @@ describe('bundle request observer middleware', () => {
         url: '/index.bundle?platform=ios&dev=true',
       } as never,
       {} as never,
-      next
+      next,
     );
 
     expect(events).toEqual([
@@ -79,7 +79,7 @@ describe('bundle request observer middleware', () => {
     const middleware = getBundleRequestObserverMiddleware(
       createProjectRoot(),
       createHarnessConfig(),
-      reporter
+      reporter,
     );
 
     middleware(
@@ -90,7 +90,7 @@ describe('bundle request observer middleware', () => {
         url: '/index.bundle?platform=android',
       } as never,
       {} as never,
-      vi.fn()
+      vi.fn(),
     );
 
     expect(events).toEqual([
@@ -106,7 +106,7 @@ describe('bundle request observer middleware', () => {
     const middleware = getBundleRequestObserverMiddleware(
       createProjectRoot(),
       createHarnessConfig(),
-      reporter
+      reporter,
     );
 
     middleware(
@@ -115,9 +115,36 @@ describe('bundle request observer middleware', () => {
         url: '/other.bundle?platform=ios',
       } as never,
       {} as never,
-      vi.fn()
+      vi.fn(),
     );
 
     expect(events).toEqual([]);
+  });
+
+  it('emits Expo virtual metro entry requests as app requests', () => {
+    const { events, reporter } = createReporter();
+    const middleware = getBundleRequestObserverMiddleware(
+      createProjectRoot(),
+      createHarnessConfig(),
+      reporter,
+    );
+
+    middleware(
+      {
+        headers: {},
+        url: '/.expo/.virtual-metro-entry.bundle?platform=android&dev=true&runModule=true&app=com.example.app',
+      } as never,
+      {} as never,
+      vi.fn(),
+    );
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'bundle_request_observed',
+        platform: 'android',
+        requestKind: 'app',
+        url: '/.expo/.virtual-metro-entry.bundle?platform=android&dev=true&runModule=true&app=com.example.app',
+      }),
+    ]);
   });
 });

--- a/packages/bundler-metro/src/__tests__/resolver.test.ts
+++ b/packages/bundler-metro/src/__tests__/resolver.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Config as HarnessConfig } from '@react-native-harness/config';
+import { createHarnessEntryPointResolver } from '../resolvers/resolver.js';
+
+const tempDirs: string[] = [];
+
+const createProjectRoot = (): string => {
+  const projectRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'rn-harness-entry-resolver-'),
+  );
+  tempDirs.push(projectRoot);
+  return projectRoot;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe('createHarnessEntryPointResolver', () => {
+  it('hijacks bare package entry points resolved from the project root', () => {
+    const projectRoot = createProjectRoot();
+    const entryPointPath = path.join(
+      projectRoot,
+      'node_modules',
+      'expo-router',
+      'entry.js',
+    );
+
+    fs.mkdirSync(path.dirname(entryPointPath), { recursive: true });
+    fs.writeFileSync(entryPointPath, 'export {};');
+
+    vi.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+
+    const resolver = createHarnessEntryPointResolver({
+      entryPoint: 'expo-router/entry',
+    } as HarnessConfig);
+
+    expect(
+      resolver(
+        {
+          originModulePath: projectRoot,
+        } as never,
+        './node_modules/expo-router/entry',
+        'android',
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        type: 'sourceFile',
+        filePath: expect.stringContaining(
+          '@react-native-harness/runtime/entry-point',
+        ),
+      }),
+    );
+  });
+});

--- a/packages/bundler-metro/src/middlewares/bundle-request-middleware.ts
+++ b/packages/bundler-metro/src/middlewares/bundle-request-middleware.ts
@@ -8,9 +8,9 @@ import {
   type HarnessBundleRequestKind,
 } from '../request-kind.js';
 
-const getRequestKind = (
-  req: IncomingMessage
-): HarnessBundleRequestKind => {
+const EXPO_VIRTUAL_ENTRY_BUNDLE = '/.expo/.virtual-metro-entry.bundle';
+
+const getRequestKind = (req: IncomingMessage): HarnessBundleRequestKind => {
   const header = req.headers[HARNESS_REQUEST_KIND_HEADER];
   const value = Array.isArray(header) ? header[0] : header;
 
@@ -20,27 +20,27 @@ const getRequestKind = (
 export const getBundleRequestObserverMiddleware = (
   projectRoot: string,
   harnessConfig: HarnessConfig,
-  reporter: Reporter
+  reporter: Reporter,
 ) => {
   const resolvedEntryPoint = getResolvedEntryPointWithoutExtension(
     projectRoot,
-    harnessConfig.entryPoint
+    harnessConfig.entryPoint,
   );
   const expectedPathname = `/${resolvedEntryPoint}.bundle`;
 
-  return (
-    req: IncomingMessage,
-    _res: ServerResponse,
-    next: NextFunction
-  ) => {
+  return (req: IncomingMessage, _res: ServerResponse, next: NextFunction) => {
     if (!req.url) {
       next();
       return;
     }
 
     const url = new URL(req.url, 'http://localhost');
+    const pathname = decodeURIComponent(url.pathname);
 
-    if (decodeURIComponent(url.pathname) === expectedPathname) {
+    if (
+      pathname === expectedPathname ||
+      pathname === EXPO_VIRTUAL_ENTRY_BUNDLE
+    ) {
       const platform = url.searchParams.get('platform');
 
       if (platform) {

--- a/packages/bundler-metro/src/resolvers/resolver.ts
+++ b/packages/bundler-metro/src/resolvers/resolver.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import type { MetroConfig } from '@react-native/metro-config';
 import type { Config as HarnessConfig } from '@react-native-harness/config';
+import { getResolvedEntryPointWithoutExtension } from '../entry-point-utils.js';
 import { createHarnessResolver } from './composite-resolver.js';
 import { createTsConfigResolver } from './tsconfig-resolver.js';
 import type { HarnessResolver, MetroResolver } from './types.js';
@@ -10,7 +11,7 @@ const require = createRequire(import.meta.url);
 
 const getExtensionlessAbsolutePath = (
   basePath: string,
-  relativePath = ''
+  relativePath = '',
 ): string => {
   const fullPath = path.resolve(basePath, relativePath);
   const parsed = path.parse(fullPath);
@@ -18,16 +19,15 @@ const getExtensionlessAbsolutePath = (
 };
 
 export const createHarnessEntryPointResolver = (
-  harnessConfig: HarnessConfig
+  harnessConfig: HarnessConfig,
 ): HarnessResolver => {
   const rootPath = path.resolve(process.cwd());
-  const expectedEntryPoint = getExtensionlessAbsolutePath(
+  const expectedEntryPoint = path.resolve(
     rootPath,
-    harnessConfig.entryPoint
+    getResolvedEntryPointWithoutExtension(rootPath, harnessConfig.entryPoint),
   );
-  const resolvedHarnessPath = require.resolve(
-    '@react-native-harness/runtime/entry-point'
-  );
+  const resolvedHarnessPath =
+    require.resolve('@react-native-harness/runtime/entry-point');
 
   return (context, moduleName, platform) => {
     void platform;
@@ -39,7 +39,7 @@ export const createHarnessEntryPointResolver = (
 
     const requestedModule = getExtensionlessAbsolutePath(
       currentOrigin,
-      moduleName
+      moduleName,
     );
 
     if (requestedModule === expectedEntryPoint) {
@@ -68,12 +68,10 @@ export const createJestGlobalsResolver = (): HarnessResolver => {
 };
 
 export const createJsxRuntimeResolver = (): HarnessResolver => {
-  const resolvedJsxRuntimePath = require.resolve(
-    '@react-native-harness/runtime/jsx-runtime'
-  );
-  const resolvedJsxDevRuntimePath = require.resolve(
-    '@react-native-harness/runtime/jsx-dev-runtime'
-  );
+  const resolvedJsxRuntimePath =
+    require.resolve('@react-native-harness/runtime/jsx-runtime');
+  const resolvedJsxDevRuntimePath =
+    require.resolve('@react-native-harness/runtime/jsx-dev-runtime');
 
   return (_context, moduleName, platform) => {
     void platform;
@@ -97,7 +95,7 @@ export const createJsxRuntimeResolver = (): HarnessResolver => {
 
 export const getHarnessResolver = (
   metroConfig: MetroConfig,
-  harnessConfig: HarnessConfig
+  harnessConfig: HarnessConfig,
 ): MetroResolver => {
   const userResolver = metroConfig.resolver?.resolveRequest;
   const resolvers: HarnessResolver[] = [

--- a/packages/platform-android/src/__tests__/adb.test.ts
+++ b/packages/platform-android/src/__tests__/adb.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../adb.js';
 import * as tools from '@react-native-harness/tools';
 import * as environment from '../environment.js';
+import * as avdConfig from '../avd-config.js';
 
 const createAbortError = () =>
   new DOMException('The operation was aborted', 'AbortError');
@@ -48,7 +49,7 @@ describe('getStartAppArgs', () => {
           user_id: 42,
           mode: 'debug',
         },
-      })
+      }),
     ).toEqual([
       'shell',
       'am',
@@ -77,7 +78,7 @@ describe('getStartAppArgs', () => {
         extras: {
           count: Number.MAX_SAFE_INTEGER + 1,
         },
-      })
+      }),
     ).toThrow('must be a safe integer');
   });
 
@@ -88,7 +89,7 @@ describe('getStartAppArgs', () => {
     } as Awaited<ReturnType<typeof tools.spawn>>);
 
     await expect(getAppUid('emulator-5554', 'com.example.app')).resolves.toBe(
-      10234
+      10234,
     );
 
     expect(spawnSpy).toHaveBeenCalledWith(expect.stringMatching(/adb$/), [
@@ -108,7 +109,7 @@ describe('getStartAppArgs', () => {
     } as Awaited<ReturnType<typeof tools.spawn>>);
 
     await expect(getLogcatTimestamp('emulator-5554')).resolves.toBe(
-      '03-12 11:35:08.000'
+      '03-12 11:35:08.000',
     );
 
     expect(spawnSpy).toHaveBeenCalledWith(expect.stringMatching(/adb$/), [
@@ -146,14 +147,19 @@ describe('getStartAppArgs', () => {
   });
 
   it('creates an AVD and appends config overrides', async () => {
+    vi.spyOn(avdConfig, 'readAvdConfig').mockResolvedValue({});
     const spawnSpy = vi
       .spyOn(tools, 'spawn')
-      .mockResolvedValue({} as Awaited<ReturnType<typeof tools.spawn>>);
+      .mockResolvedValue({} as Awaited<ReturnType<typeof tools.spawn>>)
+      .mockResolvedValueOnce({
+        stdout:
+          'id: 0 or "pixel_8"\n    Name: Pixel 8\nid: 1 or "pixel_6"\n    Name: Pixel 6\n',
+      } as Awaited<ReturnType<typeof tools.spawn>>);
     const verifyAndroidEmulatorSdk = vi
       .spyOn(environment, 'ensureAndroidSdkPackages')
       .mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(environment, 'getHostAndroidSystemImageArch').mockReturnValue(
-      'x86_64'
+      'x86_64',
     );
 
     await createAvd({
@@ -170,29 +176,128 @@ describe('getStartAppArgs', () => {
       'platforms;android-35',
       'system-images;android-35;default;x86_64',
     ]);
-    expect(spawnSpy).toHaveBeenNthCalledWith(1, 'bash', [
-      '-lc',
-      expect.stringContaining(
-        'create avd --force --name "Pixel_8_API_35" --package "system-images;android-35;default;x86_64" --device "pixel_8"'
-      ),
-    ]);
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/avdmanager$/),
+      ['list', 'device'],
+    );
     expect(spawnSpy).toHaveBeenNthCalledWith(2, 'bash', [
       '-lc',
       expect.stringContaining(
-        `'disk.dataPartition.size=1G' 'vm.heapSize=1G' >> `
+        'create avd --force --name "Pixel_8_API_35" --package "system-images;android-35;default;x86_64" --device "pixel_8" -p ',
+      ),
+    ]);
+    expect(spawnSpy).toHaveBeenNthCalledWith(3, 'bash', [
+      '-lc',
+      expect.stringContaining(`'avd.ini.encoding=UTF-8' 'path=`),
+    ]);
+    expect(spawnSpy).toHaveBeenNthCalledWith(4, 'bash', [
+      '-lc',
+      expect.stringContaining(
+        `'disk.dataPartition.size=1G' 'vm.heapSize=1G' >> `,
       ),
     ]);
   });
 
-  it('creates an AVD with arm64 system image packages on arm64 hosts', async () => {
-    vi.spyOn(tools, 'spawn').mockResolvedValue(
-      {} as Awaited<ReturnType<typeof tools.spawn>>
+  it('recreates the companion ini file when avdmanager leaves it missing', async () => {
+    vi.spyOn(avdConfig, 'readAvdConfig').mockResolvedValue({});
+    const spawnSpy = vi
+      .spyOn(tools, 'spawn')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof tools.spawn>>)
+      .mockResolvedValueOnce({
+        stdout: 'id: 0 or "pixel_6"\n    Name: Pixel 6\n',
+      } as Awaited<ReturnType<typeof tools.spawn>>);
+    vi.spyOn(environment, 'ensureAndroidSdkPackages').mockResolvedValue(
+      '/tmp/android-sdk',
     );
+    vi.spyOn(environment, 'getHostAndroidSystemImageArch').mockReturnValue(
+      'x86_64',
+    );
+
+    await createAvd({
+      name: 'Pixel_6_API_35',
+      apiLevel: 35,
+      profile: 'pixel_6',
+      diskSize: '1G',
+      heapSize: '1G',
+    });
+
+    expect(spawnSpy).toHaveBeenNthCalledWith(3, 'bash', [
+      '-lc',
+      expect.stringContaining(`'avd.ini.encoding=UTF-8' 'path=`),
+    ]);
+    expect(spawnSpy).toHaveBeenNthCalledWith(4, 'bash', [
+      '-lc',
+      expect.stringContaining(
+        `'disk.dataPartition.size=1G' 'vm.heapSize=1G' >> `,
+      ),
+    ]);
+  });
+
+  it('throws an actionable error when the requested AVD profile is unavailable', async () => {
+    vi.spyOn(tools, 'spawn').mockResolvedValueOnce({
+      stdout:
+        'id: 0 or "pixel_8"\n    Name: Pixel 8\nid: 1 or "pixel_6"\n    Name: Pixel 6\n',
+    } as Awaited<ReturnType<typeof tools.spawn>>);
+    vi.spyOn(environment, 'ensureAndroidSdkPackages').mockResolvedValue(
+      '/tmp/android-sdk',
+    );
+    vi.spyOn(environment, 'getHostAndroidSystemImageArch').mockReturnValue(
+      'x86_64',
+    );
+
+    await expect(
+      createAvd({
+        name: 'Pixel_8_Pro_API_35',
+        apiLevel: 35,
+        profile: 'pixel_8_pro',
+        diskSize: '1G',
+        heapSize: '1G',
+      }),
+    ).rejects.toThrow(
+      'Android AVD profile "pixel_8_pro" is not available on this machine. Available profiles: pixel_8, pixel_6',
+    );
+  });
+
+  it('throws a clear error when avdmanager does not create config.ini', async () => {
+    vi.spyOn(avdConfig, 'readAvdConfig').mockResolvedValue(null);
+    vi.spyOn(tools, 'spawn')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof tools.spawn>>)
+      .mockResolvedValueOnce({
+        stdout: 'id: 0 or "pixel_6"\n    Name: Pixel 6\n',
+      } as Awaited<ReturnType<typeof tools.spawn>>);
+    vi.spyOn(environment, 'ensureAndroidSdkPackages').mockResolvedValue(
+      '/tmp/android-sdk',
+    );
+    vi.spyOn(environment, 'getHostAndroidSystemImageArch').mockReturnValue(
+      'x86_64',
+    );
+
+    await expect(
+      createAvd({
+        name: 'Pixel_6_API_35',
+        apiLevel: 35,
+        profile: 'pixel_6',
+        diskSize: '1G',
+        heapSize: '1G',
+      }),
+    ).rejects.toThrow(
+      'Android AVD "Pixel_6_API_35" was created, but config.ini was not found at ',
+    );
+  });
+
+  it('creates an AVD with arm64 system image packages on arm64 hosts', async () => {
+    vi.spyOn(avdConfig, 'readAvdConfig').mockResolvedValue({});
+    vi.spyOn(tools, 'spawn')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof tools.spawn>>)
+      .mockResolvedValueOnce({
+        stdout: 'id: 0 or "pixel_8"\n    Name: Pixel 8\n',
+      } as Awaited<ReturnType<typeof tools.spawn>>);
     const ensureAndroidSdkPackages = vi
       .spyOn(environment, 'ensureAndroidSdkPackages')
       .mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(environment, 'getHostAndroidSystemImageArch').mockReturnValue(
-      'arm64-v8a'
+      'arm64-v8a',
     );
 
     await createAvd({
@@ -241,7 +346,7 @@ describe('getStartAppArgs', () => {
     child.emit('close', 1, null);
 
     await expect(startPromise).rejects.toThrow(
-      'Unknown AVD name [Pixel_8_API_35]'
+      'Unknown AVD name [Pixel_8_API_35]',
     );
   });
 
@@ -271,7 +376,7 @@ describe('getStartAppArgs', () => {
     child.emit('close', 1, null);
 
     await expect(startPromise).rejects.toThrow(
-      'emulator: panic: broken config'
+      'emulator: panic: broken config',
     );
   });
 
@@ -291,7 +396,7 @@ describe('getStartAppArgs', () => {
     vi.spyOn(emulatorProcess, 'startDetachedProcess').mockReturnValue(
       child as unknown as ReturnType<
         typeof emulatorProcess.startDetachedProcess
-      >
+      >,
     );
 
     const startPromise = startEmulator('Pixel_8_API_35');
@@ -317,7 +422,7 @@ describe('getStartAppArgs', () => {
       .mockReturnValue(
         child as unknown as ReturnType<
           typeof emulatorProcess.startDetachedProcess
-        >
+        >,
       );
 
     const startPromise = startEmulator('Pixel_8_API_35');
@@ -326,7 +431,7 @@ describe('getStartAppArgs', () => {
 
     expect(startDetachedProcess).toHaveBeenCalledWith(
       expect.stringMatching(/emulator$/),
-      expect.arrayContaining(['-no-snapshot-load', '-no-snapshot-save'])
+      expect.arrayContaining(['-no-snapshot-load', '-no-snapshot-save']),
     );
   });
 
@@ -345,22 +450,22 @@ describe('getStartAppArgs', () => {
       .mockReturnValue(
         child as unknown as ReturnType<
           typeof emulatorProcess.startDetachedProcess
-        >
+        >,
       );
 
     const startPromise = startEmulator(
       'Pixel_8_API_35',
-      'clean-snapshot-generation'
+      'clean-snapshot-generation',
     );
     await vi.runAllTimersAsync();
     await startPromise;
 
     expect(startDetachedProcess).toHaveBeenCalledWith(
       expect.stringMatching(/emulator$/),
-      expect.arrayContaining(['-no-snapshot-load'])
+      expect.arrayContaining(['-no-snapshot-load']),
     );
     expect(startDetachedProcess.mock.calls[0]?.[1]).not.toContain(
-      '-no-snapshot-save'
+      '-no-snapshot-save',
     );
   });
 
@@ -379,7 +484,7 @@ describe('getStartAppArgs', () => {
       .mockReturnValue(
         child as unknown as ReturnType<
           typeof emulatorProcess.startDetachedProcess
-        >
+        >,
       );
 
     const startPromise = startEmulator('Pixel_8_API_35', 'snapshot-reuse');
@@ -388,10 +493,10 @@ describe('getStartAppArgs', () => {
 
     expect(startDetachedProcess).toHaveBeenCalledWith(
       expect.stringMatching(/emulator$/),
-      expect.arrayContaining(['-no-snapshot-save'])
+      expect.arrayContaining(['-no-snapshot-save']),
     );
     expect(startDetachedProcess.mock.calls[0]?.[1]).not.toContain(
-      '-no-snapshot-load'
+      '-no-snapshot-load',
     );
   });
 
@@ -459,7 +564,7 @@ describe('getStartAppArgs', () => {
 
     const waitPromise = waitForBoot(
       'Pixel_8_API_35',
-      new AbortController().signal
+      new AbortController().signal,
     );
 
     await vi.advanceTimersByTimeAsync(1000);
@@ -482,7 +587,7 @@ describe('getStartAppArgs', () => {
 
     const waitPromise = waitForEmulatorDisconnect(
       'emulator-5554',
-      new AbortController().signal
+      new AbortController().signal,
     );
 
     await vi.advanceTimersByTimeAsync(1000);

--- a/packages/platform-android/src/adb.ts
+++ b/packages/platform-android/src/adb.ts
@@ -5,6 +5,11 @@ import type { ChildProcessByStdio } from 'node:child_process';
 import { access, rm } from 'node:fs/promises';
 import type { Readable } from 'node:stream';
 import {
+  getAvdConfigPath,
+  getAvdDirectory,
+  readAvdConfig,
+} from './avd-config.js';
+import {
   ensureAndroidEmulatorAvailable,
   ensureAndroidSdkPackages,
   getAdbBinaryPath,
@@ -51,11 +56,6 @@ const waitWithSignal = async (
 
   await Promise.race([wait(ms), waitForAbort(signal)]);
 };
-
-const getAvdConfigPath = (name: string): string =>
-  `${
-    process.env.ANDROID_AVD_HOME ?? `${process.env.HOME}/.android/avd`
-  }/${name}.avd/config.ini`;
 
 const EMULATOR_STARTUP_OBSERVATION_TIMEOUT_MS = 5000;
 const EMULATOR_OUTPUT_BUFFER_LIMIT = 16 * 1024;
@@ -158,6 +158,68 @@ export const verifyAndroidEmulatorSdk = async (
   apiLevel: number,
 ): Promise<void> => {
   await ensureAndroidSdkPackages(getRequiredEmulatorPackages(apiLevel));
+};
+
+const listAvdProfiles = async (): Promise<string[]> => {
+  const { stdout } = await spawn(getAvdManagerBinaryPath(), ['list', 'device']);
+
+  return stdout
+    .split('\n')
+    .map((line) => line.match(/^id:\s+\d+\s+or\s+"([^"]+)"/i)?.[1]?.trim())
+    .filter((profile): profile is string => profile != null && profile !== '');
+};
+
+const ensureAvdProfileAvailable = async (profile: string): Promise<void> => {
+  const availableProfiles = await listAvdProfiles();
+
+  if (availableProfiles.includes(profile)) {
+    return;
+  }
+
+  const availableProfilesList =
+    availableProfiles.length > 0
+      ? availableProfiles.join(', ')
+      : 'None reported by avdmanager.';
+
+  throw new Error(
+    `Android AVD profile "${profile}" is not available on this machine. Available profiles: ${availableProfilesList}`,
+  );
+};
+
+const ensureAvdConfigExists = async (name: string): Promise<string> => {
+  const configPath = getAvdConfigPath(name);
+
+  if ((await readAvdConfig(name)) == null) {
+    throw new Error(
+      `Android AVD "${name}" was created, but config.ini was not found at ${configPath}.`,
+    );
+  }
+
+  return configPath;
+};
+
+const getAvdIniPath = (name: string): string => {
+  const avdHome =
+    process.env.ANDROID_AVD_HOME ?? `${process.env.HOME}/.android/avd`;
+  return `${avdHome}/${name}.ini`;
+};
+
+const ensureAvdIniExists = async ({
+  name,
+  apiLevel,
+}: {
+  name: string;
+  apiLevel: number;
+}): Promise<string> => {
+  const iniPath = getAvdIniPath(name);
+
+  const avdDirectory = getAvdDirectory(name);
+  await spawn('bash', [
+    '-lc',
+    `printf '%s\n%s\n%s\n%s\n' 'avd.ini.encoding=UTF-8' 'path=${avdDirectory}' 'path.rel=avd/${name}.avd' 'target=android-${apiLevel}' > "${iniPath}"`,
+  ]);
+
+  return iniPath;
 };
 
 export const getStartAppArgs = (
@@ -354,15 +416,16 @@ export const createAvd = async ({
   );
 
   await verifyAndroidEmulatorSdk(apiLevel);
+  await ensureAvdProfileAvailable(profile);
   await spawn('bash', [
     '-lc',
-    `printf 'no\n' | "${getAvdManagerBinaryPath()}" create avd --force --name "${name}" --package "${systemImagePackage}" --device "${profile}"`,
+    `printf 'no\n' | "${getAvdManagerBinaryPath()}" create avd --force --name "${name}" --package "${systemImagePackage}" --device "${profile}" -p "${getAvdDirectory(name)}"`,
   ]);
+  await ensureAvdIniExists({ name, apiLevel });
+  const configPath = await ensureAvdConfigExists(name);
   await spawn('bash', [
     '-lc',
-    `printf '%s\n%s\n' 'disk.dataPartition.size=${diskSize}' 'vm.heapSize=${heapSize}' >> "${getAvdConfigPath(
-      name,
-    )}"`,
+    `printf '%s\n%s\n' 'disk.dataPartition.size=${diskSize}' 'vm.heapSize=${heapSize}' >> "${configPath}"`,
   ]);
 };
 

--- a/packages/runtime/src/disableHMRWhenReady.test.ts
+++ b/packages/runtime/src/disableHMRWhenReady.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { disableHMRWhenReady } from './disableHMRWhenReady.js';
+
+const mocks = vi.hoisted(() => ({
+  Platform: { OS: 'android' },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: mocks.Platform,
+}));
+
+describe('disableHMRWhenReady', () => {
+  beforeEach(() => {
+    mocks.Platform.OS = 'android';
+  });
+
+  it('resolves when HMR setup never becomes available', async () => {
+    const disable = vi.fn(() => {
+      throw new Error('Expected HMRClient.setup() call at startup.');
+    });
+
+    await expect(disableHMRWhenReady(disable, 2, 0)).resolves.toBeUndefined();
+    expect(disable).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects unexpected disable errors', async () => {
+    const error = new Error('boom');
+    const disable = vi.fn(() => {
+      throw error;
+    });
+
+    await expect(disableHMRWhenReady(disable, 2, 0)).rejects.toBe(error);
+  });
+
+  it('skips disabling HMR on web', async () => {
+    mocks.Platform.OS = 'web';
+    const disable = vi.fn();
+
+    await expect(disableHMRWhenReady(disable, 2, 0)).resolves.toBeUndefined();
+    expect(disable).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/disableHMRWhenReady.ts
+++ b/packages/runtime/src/disableHMRWhenReady.ts
@@ -1,9 +1,11 @@
-import { Platform } from "react-native";
+import { Platform } from 'react-native';
+
+const HMR_SETUP_ERROR = 'Expected HMRClient.setup() call at startup.';
 
 export function disableHMRWhenReady(
   disable: () => void,
   retriesLeft: number,
-  retryDelay = 10
+  retryDelay = 10,
 ) {
   return new Promise<void>((resolve, reject) => {
     if (Platform.OS === 'web') {
@@ -17,12 +19,18 @@ export function disableHMRWhenReady(
         disable();
         resolve();
       } catch (error) {
-        if (
-          remaining > 0 &&
-          error instanceof Error &&
-          error.message.includes('Expected HMRClient.setup() call at startup.')
-        ) {
+        const isMissingHMRSetupError =
+          error instanceof Error && error.message.includes(HMR_SETUP_ERROR);
+
+        if (remaining > 0 && isMissingHMRSetupError) {
           setTimeout(() => attempt(remaining - 1), retryDelay);
+          return;
+        }
+
+        // Expo's metro runtime does not guarantee that React Native's HMRClient
+        // is initialized, so disabling HMR is best-effort in that environment.
+        if (isMissingHMRSetupError) {
+          resolve();
           return;
         }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,7 @@
 import './polyfills.js';
 import './globals.js';
 
+export { createElement } from './jsx/jsx-runtime.js';
 export { UI as ReactNativeHarness } from './ui/index.js';
 export * from './spy/index.js';
 export * from './expect/index.js';

--- a/packages/runtime/src/initialize.ts
+++ b/packages/runtime/src/initialize.ts
@@ -22,11 +22,17 @@ const HMRClient =
 
 // Wait for HMRClient to be initialized
 setTimeout(() => {
-  void disableHMRWhenReady(() => HMRClient.disable(), 50).then(() =>
-    getClient().then((client) =>
-      client.rpc.reportReady(getDeviceDescriptor())
-    )
-  );
+  void (async () => {
+    try {
+      await disableHMRWhenReady(() => HMRClient.disable(), 50);
+      const client = await getClient();
+
+      const deviceDescriptor = getDeviceDescriptor();
+      await client.rpc.reportReady(deviceDescriptor);
+    } catch (error) {
+      console.error('Failed to initialize React Native Harness', error);
+    }
+  })();
 });
 
 // Re-throw fatal errors

--- a/packages/runtime/src/jsx/jsx-runtime.ts
+++ b/packages/runtime/src/jsx/jsx-runtime.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { View } from 'react-native';
 import * as ReactJSXRuntime from 'react/jsx-runtime';
 import { getHarnessGlobal } from '../globals.js';
@@ -35,4 +36,18 @@ export function jsxs(
   key?: React.Key,
 ): React.ReactElement {
   return wrap(type, props, key, true);
+}
+
+export function createElement(
+  type: React.ElementType,
+  props?: Record<string, unknown> | null,
+  ...children: React.ReactNode[]
+): React.ReactElement {
+  const disableViewFlattening = getHarnessGlobal().disableViewFlattening;
+
+  if (disableViewFlattening && type === View) {
+    props = { ...props, collapsable: false };
+  }
+
+  return React.createElement(type, props, ...children);
 }


### PR DESCRIPTION
## Summary
- harden Android AVD creation and update the related tests
- expose `createElement` from the Harness runtime and make bridge startup tolerate Expo's Metro runtime behavior
- resolve package-style Expo entry points before hijacking Metro and accept Expo's virtual Metro entry bundle during startup detection

## Testing
- not run end-to-end in CI from this branch
- validated manually against `../expo-playground` using equivalent `patch-package` patches