### PR TITLE
chore: pin GitHub Action SHAs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,13 +33,13 @@ jobs:
       DEBUG: 'Metro:*'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Reclaim disk space
-        uses: AdityaGarg8/remove-unwanted-software@v5
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
         with:
           remove-dotnet: true
           remove-haskell: true
@@ -47,12 +47,12 @@ jobs:
           remove-docker-images: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.10.0'
           cache: 'pnpm'
@@ -66,14 +66,14 @@ jobs:
           pnpm nx run-many -t build --projects="packages/*"
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Restore APK from cache
         id: cache-apk-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: apps/playground/android/app/build/outputs/apk/debug/app-debug.apk
           key: apk-playground
@@ -86,7 +86,7 @@ jobs:
 
       - name: Save APK to cache
         if: steps.cache-apk-restore.outputs.cache-hit != 'true' && success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: apps/playground/android/app/build/outputs/apk/debug/app-debug.apk
           key: apk-playground
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload Harness logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: harness-logs-e2e-android
           path: apps/playground/.harness/logs
@@ -122,24 +122,24 @@ jobs:
       DEBUG: 'Metro:*'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.10.0'
           cache: 'pnpm'
 
       - name: Setup Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '26.0'
 
@@ -156,14 +156,14 @@ jobs:
 
       - name: Restore app from cache
         id: cache-app-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./apps/playground/ios/build/Build/Products/Debug-iphonesimulator/HarnessPlayground.app
           key: ios-app-playground
 
       - name: CocoaPods cache
         if: steps.cache-app-restore.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ./apps/playground/ios/Pods
@@ -187,7 +187,7 @@ jobs:
 
       - name: Save app to cache
         if: steps.cache-app-restore.outputs.cache-hit != 'true' && success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./apps/playground/ios/build/Build/Products/Debug-iphonesimulator/HarnessPlayground.app
           key: ios-app-playground
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload Harness logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: harness-logs-e2e-ios
           path: apps/playground/.harness/logs
@@ -223,18 +223,18 @@ jobs:
       DEBUG: 'Metro:*'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.10.0'
           cache: 'pnpm'
@@ -261,7 +261,7 @@ jobs:
 
       - name: Upload Harness logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: harness-logs-e2e-web
           path: apps/playground/.harness/logs
@@ -278,13 +278,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Reclaim disk space
-        uses: AdityaGarg8/remove-unwanted-software@v5
+        uses: AdityaGarg8/remove-unwanted-software@90e01b21170618765a73370fcc3abbd1684a7793 # v5
         with:
           remove-dotnet: true
           remove-haskell: true
@@ -292,12 +292,12 @@ jobs:
           remove-docker-images: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.10.0'
           cache: 'pnpm'
@@ -311,14 +311,14 @@ jobs:
           pnpm nx run-many -t build --projects="packages/*"
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Restore APK from cache
         id: cache-apk-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: apps/playground/android/app/build/outputs/apk/debug/app-debug.apk
           key: apk-playground
@@ -331,7 +331,7 @@ jobs:
 
       - name: Save APK to cache
         if: steps.cache-apk-restore.outputs.cache-hit != 'true' && success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: apps/playground/android/app/build/outputs/apk/debug/app-debug.apk
           key: apk-playground
@@ -375,7 +375,7 @@ jobs:
 
       - name: Upload Harness logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: harness-logs-crash-validate-android
           path: apps/playground/.harness/logs
@@ -391,24 +391,24 @@ jobs:
       DEBUG: 'Metro:*'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24.10.0'
           cache: 'pnpm'
 
       - name: Setup Xcode 26
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '26.0'
 
@@ -425,14 +425,14 @@ jobs:
 
       - name: Restore app from cache
         id: cache-app-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./apps/playground/ios/build/Build/Products/Debug-iphonesimulator/HarnessPlayground.app
           key: ios-app-playground
 
       - name: CocoaPods cache
         if: steps.cache-app-restore.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ./apps/playground/ios/Pods
@@ -456,7 +456,7 @@ jobs:
 
       - name: Save app to cache
         if: steps.cache-app-restore.outputs.cache-hit != 'true' && success()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./apps/playground/ios/build/Build/Products/Debug-iphonesimulator/HarnessPlayground.app
           key: ios-app-playground
@@ -500,7 +500,7 @@ jobs:
 
       - name: Upload Harness logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: harness-logs-crash-validate-ios
           path: apps/playground/.harness/logs

--- a/packages/github-action/src/action.yml
+++ b/packages/github-action/src/action.yml
@@ -65,7 +65,7 @@ runs:
           exit 1
         fi
     - name: Metro bundler cache (.harness/metro-cache)
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/metro-cache
         key: ${{ runner.os }}-metro-cache-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/npm-shrinkwrap.json', '**/pnpm-lock.yaml', '**/yarn.lock', '**/metro.config.js', '**/metro.config.cjs', '**/metro.config.mjs', '**/metro.config.ts', '**/babel.config.js', '**/babel.config.cjs', '**/babel.config.mjs', '**/babel.config.ts', '**/babel.config.json') }}
@@ -74,7 +74,7 @@ runs:
     - name: Restore Harness cache
       id: cache-harness-restore
       if: fromJson(steps.load-config.outputs.config).platformId == 'ios'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/cache
         key: harness-ios-${{ runner.os }}-${{ hashFiles(format('{0}/.harness/cache/**/cache.json', steps.load-config.outputs.projectRoot)) }}
@@ -132,7 +132,7 @@ runs:
         CACHE_KEY="avd-$AVD_NAME-$ARCH-$AVD_CONFIG_HASH"
         echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
     - name: Restore AVD cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: avd-cache
       if: ${{ fromJson(steps.load-config.outputs.config).platformId == 'android' && fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled }}
       with:
@@ -221,7 +221,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-${{ fromJson(steps.load-config.outputs.config).platformId }}
         path: |
@@ -230,7 +230,7 @@ runs:
         if-no-files-found: ignore
     - name: Save AVD cache
       if: ${{ always() && fromJson(steps.load-config.outputs.config).platformId == 'android' && fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled && steps.avd-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.android/avd
@@ -238,13 +238,13 @@ runs:
         key: ${{ steps.avd-key.outputs.key }}
     - name: Save Harness cache
       if: ${{ always() && fromJson(steps.load-config.outputs.config).platformId == 'ios' && steps.cache-harness-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/cache
         key: ${{ steps.cache-harness-restore.outputs.cache-primary-key }}
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-${{ fromJson(steps.load-config.outputs.config).platformId }}
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/crash-reports/**/*

--- a/packages/github-action/src/android/action.yml
+++ b/packages/github-action/src/android/action.yml
@@ -98,7 +98,7 @@ runs:
         echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
     - name: Restore AVD cache
       if: ${{ fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: avd-cache
       with:
         path: |
@@ -150,7 +150,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-android
         path: |
@@ -159,7 +159,7 @@ runs:
         if-no-files-found: ignore
     - name: Save AVD cache
       if: ${{ always() && fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled && steps.avd-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.android/avd
@@ -167,7 +167,7 @@ runs:
         key: ${{ steps.avd-key.outputs.key }}
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-android
         path: ${{ inputs.projectRoot }}/.harness/crash-reports/**/*

--- a/packages/github-action/src/ios/action.yml
+++ b/packages/github-action/src/ios/action.yml
@@ -87,7 +87,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-ios
         path: |
@@ -96,7 +96,7 @@ runs:
         if-no-files-found: ignore
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-ios
         path: ${{ inputs.projectRoot }}/.harness/crash-reports/**/*

--- a/packages/github-action/src/web/action.yml
+++ b/packages/github-action/src/web/action.yml
@@ -115,7 +115,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-chromium
         path: |
@@ -124,7 +124,7 @@ runs:
         if-no-files-found: ignore
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-web
         path: ${{ inputs.projectRoot }}/.harness/crash-reports/**/*


### PR DESCRIPTION
This PR hardens our GitHub Actions setup by replacing floating major-version action references with exact release SHAs in the E2E workflow and the composite action YAMLs under `packages/github-action/`. From a user perspective, behavior stays the same, but workflow runs are now locked to reviewed action revisions instead of whatever the major tag points to later.

Closes #107 

## Summary
- pin every external action used by `.github/workflows/e2e-tests.yml` and `packages/github-action/src/*.yml` to the commit SHA for the latest release under the currently used major tag
- keep local `uses: ./` references unchanged while adding inline release comments for traceability
- verify the final pins against the source repositories and confirm no `@v*` references remain in the targeted YAML files

## Verification
- resolved release tags and SHAs with `gh api` for each referenced action repository
- confirmed no remaining major-tag `uses:` entries in the targeted YAML files