### PR TITLE
fix(platform-android): avoid probing physical devices as emulators

### DIFF
--- a/.nx/version-plans/version-plan-1777795200000.md
+++ b/.nx/version-plans/version-plan-1777795200000.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness will stop trying to treat connected physical Android devices as emulators. If you run against an Android emulator and also have a physical device plugged in, Harness will now pick the emulator cleanly instead of failing during device resolution.

--- a/packages/platform-android/src/__tests__/adb-id.test.ts
+++ b/packages/platform-android/src/__tests__/adb-id.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAdbId, isAdbIdEmulator } from '../adb-id.js';
+import * as adb from '../adb.js';
+
+describe('adb id resolution', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('identifies emulator adb ids', () => {
+    expect(isAdbIdEmulator('emulator-5554')).toBe(true);
+    expect(isAdbIdEmulator('device-serial-001')).toBe(false);
+  });
+
+  it('skips non-emulator ids when resolving an emulator device', async () => {
+    vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([
+      'device-serial-001',
+      'emulator-5554',
+    ]);
+    vi.spyOn(adb, 'getEmulatorName').mockResolvedValue('Test_AVD_API_35');
+
+    await expect(
+      getAdbId({
+        type: 'emulator',
+        name: 'Test_AVD_API_35',
+      }),
+    ).resolves.toBe('emulator-5554');
+  });
+
+  it('resolves matching physical device by manufacturer and model', async () => {
+    vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([
+      'device-serial-001',
+      'emulator-5554',
+    ]);
+    vi.spyOn(adb, 'getDeviceInfo').mockImplementation(async (adbId) => {
+      const results: Record<string, { manufacturer: string; model: string }> = {
+        'device-serial-001': { manufacturer: 'Acme', model: 'Model A1' },
+        'emulator-5554': { manufacturer: 'Emulator', model: 'Emulator Model' },
+      };
+      return results[adbId] || null;
+    });
+
+    await expect(
+      getAdbId({
+        type: 'physical',
+        manufacturer: 'acme',
+        model: 'model a1',
+      }),
+    ).resolves.toBe('device-serial-001');
+  });
+});

--- a/packages/platform-android/src/adb-id.ts
+++ b/packages/platform-android/src/adb-id.ts
@@ -16,6 +16,10 @@ export const getAdbId = async (
 
   for (const adbId of adbIds) {
     if (isAndroidDeviceEmulator(device)) {
+      if (!isAdbIdEmulator(adbId)) {
+        continue;
+      }
+
       const emulatorName = await adb.getEmulatorName(adbId);
 
       if (emulatorName === device.name) {

--- a/packages/platform-android/vite.config.ts
+++ b/packages/platform-android/vite.config.ts
@@ -1,0 +1,18 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/platform-android',
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));


### PR DESCRIPTION
## Description

When we specify an android emulator as the harness runner like below and connect a physical device, we get the following error.

```js
const config = {
  runners: [
    androidPlatform({
      name: 'android',
      device: androidEmulator('Pixel_Tablet_Rootable'),
      bundleId: 'com.example',
    }),
  ]
};

export default config;
```

```
SubprocessError: Command failed with exit code 1: ~/Library/Android/sdk/platform-tools/adb -s <device-id> emu avd name
    at checkFailure (file:///path/to/node_modules/nano-spawn/source/result.js:40:9)
    at getResult (file:///path/to/node_modules/nano-spawn/source/result.js:17:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async Module.getEmulatorName (file:///path/to/node_modules/@react-native-harness/platform-android/dist/adb.js:195:24)
    at async getAdbId (file:///path/to/node_modules/@react-native-harness/platform-android/dist/adb-id.js:10:34)
    at async getAndroidEmulatorPlatformInstance (file:///path/to/node_modules/@react-native-harness/platform-android/dist/instance.js:108:17)
    at async Object.work (file:///path/to/node_modules/@react-native-harness/jest/dist/harness.js:217:36)
    at async withPlatformReadyTimeout (file:///path/to/node_modules/@react-native-harness/jest/dist/harness.js:36:16)
    at async Promise.all (index 1)
    at async file:///path/to/node_modules/@react-native-harness/jest/dist/harness.js:202:24
```

This is just because `getAdbId` tries to get an emulator name from a physical device.
This patch fixes Android emulator device resolution to skip non-emulator ADB IDs before querying AVD name. Also adds a focused regression test suite.

## Testing

I manually tested with that previously problematic situation.