### PR TITLE
feat(platform-web): expose ignoreDefaultArgs in browser config

### DIFF
--- a/.nx/version-plans/version-plan-1778726400000.md
+++ b/.nx/version-plans/version-plan-1778726400000.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness on web can now pass Playwright launch arg overrides through the browser config, so you can turn off defaults like `--enable-automation` without forking the runner.

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
           exit 1
         fi
     - name: Metro bundler cache (.harness/metro-cache)
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/metro-cache
         key: ${{ runner.os }}-metro-cache-${{ hashFiles('**/bun.lock', '**/bun.lockb', '**/package-lock.json', '**/npm-shrinkwrap.json', '**/pnpm-lock.yaml', '**/yarn.lock', '**/metro.config.js', '**/metro.config.cjs', '**/metro.config.mjs', '**/metro.config.ts', '**/babel.config.js', '**/babel.config.cjs', '**/babel.config.mjs', '**/babel.config.ts', '**/babel.config.json') }}
@@ -74,7 +74,7 @@ runs:
     - name: Restore Harness cache
       id: cache-harness-restore
       if: fromJson(steps.load-config.outputs.config).platformId == 'ios'
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/cache
         key: harness-ios-${{ runner.os }}-${{ hashFiles(format('{0}/.harness/cache/**/cache.json', steps.load-config.outputs.projectRoot)) }}
@@ -132,7 +132,7 @@ runs:
         CACHE_KEY="avd-$AVD_NAME-$ARCH-$AVD_CONFIG_HASH"
         echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
     - name: Restore AVD cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: avd-cache
       if: ${{ fromJson(steps.load-config.outputs.config).platformId == 'android' && fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled }}
       with:
@@ -221,7 +221,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-${{ fromJson(steps.load-config.outputs.config).platformId }}
         path: |
@@ -230,7 +230,7 @@ runs:
         if-no-files-found: ignore
     - name: Save AVD cache
       if: ${{ always() && fromJson(steps.load-config.outputs.config).platformId == 'android' && fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled && steps.avd-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.android/avd
@@ -238,13 +238,13 @@ runs:
         key: ${{ steps.avd-key.outputs.key }}
     - name: Save Harness cache
       if: ${{ always() && fromJson(steps.load-config.outputs.config).platformId == 'ios' && steps.cache-harness-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/cache
         key: ${{ steps.cache-harness-restore.outputs.cache-primary-key }}
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-${{ fromJson(steps.load-config.outputs.config).platformId }}
         path: ${{ steps.load-config.outputs.projectRoot }}/.harness/crash-reports/**/*

--- a/actions/android/action.yml
+++ b/actions/android/action.yml
@@ -98,7 +98,7 @@ runs:
         echo "key=$CACHE_KEY" >> $GITHUB_OUTPUT
     - name: Restore AVD cache
       if: ${{ fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: avd-cache
       with:
         path: |
@@ -150,7 +150,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-android
         path: |
@@ -159,7 +159,7 @@ runs:
         if-no-files-found: ignore
     - name: Save AVD cache
       if: ${{ always() && fromJson(steps.load-config.outputs.config).config.device.type == 'emulator' && fromJson(steps.load-config.outputs.config).action.avdCachingEnabled && steps.avd-cache.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.android/avd
@@ -167,7 +167,7 @@ runs:
         key: ${{ steps.avd-key.outputs.key }}
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-android
         path: ${{ inputs.projectRoot }}/.harness/crash-reports/**/*

--- a/actions/ios/action.yml
+++ b/actions/ios/action.yml
@@ -87,7 +87,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-ios
         path: |
@@ -96,7 +96,7 @@ runs:
         if-no-files-found: ignore
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-ios
         path: ${{ inputs.projectRoot }}/.harness/crash-reports/**/*

--- a/actions/shared/index.cjs
+++ b/actions/shared/index.cjs
@@ -4427,7 +4427,7 @@ var ConfigSchema = external_exports.object({
   coverage: external_exports.object({
     root: external_exports.string().optional().describe(`Root directory for coverage instrumentation in monorepo setups. Specifies the directory from which coverage data should be collected. Use ".." for create-react-native-library projects where tests run from example/ but source files are in parent directory. Passed to babel-plugin-istanbul's cwd option.`)
   }).optional(),
-  forwardClientLogs: external_exports.boolean().optional().default(false).describe("Enable forwarding of console.log, console.warn, console.error, and other console method calls from the React Native app to the terminal. When enabled, all console output from your app will be displayed in the test runner terminal with styled level indicators (log, warn, error)."),
+  forwardClientLogs: external_exports.boolean().optional().default(false).describe("Enable forwarding of console.log, console.warn, console.error, and other console method calls from the React Native app during the active test run. When enabled, app console output is attached to the active test result's console output."),
   // Deprecated property - used for migration detection
   include: external_exports.array(external_exports.string()).optional()
 }).refine((config) => {

--- a/actions/web/action.yml
+++ b/actions/web/action.yml
@@ -115,7 +115,7 @@ runs:
         fi
     - name: Upload visual test artifacts
       if: always() && inputs.uploadVisualTestArtifacts == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: visual-test-diffs-chromium
         path: |
@@ -124,7 +124,7 @@ runs:
         if-no-files-found: ignore
     - name: Upload crash report artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: harness-crash-reports-web
         path: ${{ inputs.projectRoot }}/.harness/crash-reports/**/*

--- a/packages/platform-web/src/config.ts
+++ b/packages/platform-web/src/config.ts
@@ -8,6 +8,7 @@ export const WebBrowserConfigSchema = z.object({
   headless: z.boolean().default(true),
   channel: z.string().optional(),
   executablePath: z.string().optional(),
+  ignoreDefaultArgs: z.union([z.boolean(), z.array(z.string())]).optional(),
 });
 
 export const WebPlatformConfigSchema = z.object({

--- a/packages/platform-web/src/runner.ts
+++ b/packages/platform-web/src/runner.ts
@@ -86,6 +86,7 @@ const getWebRunner = async (
       headless: parsedConfig.browser.headless,
       channel: parsedConfig.browser.channel,
       executablePath: parsedConfig.browser.executablePath,
+      ignoreDefaultArgs: parsedConfig.browser.ignoreDefaultArgs,
     });
 
     const context = await browser.newContext();

--- a/website/src/docs/getting-started/configuration.mdx
+++ b/website/src/docs/getting-started/configuration.mdx
@@ -127,6 +127,8 @@ A test runner defines how tests are executed on a specific platform. React Nativ
 Runner-specific launch options belong inside each runner config via `appLaunchOptions`.
 They are passed whenever Harness launches or relaunches the app for that runner.
 
+For `@react-native-harness/platform-web`, browser launch options such as `ignoreDefaultArgs` belong on the browser config passed to `chromium`, `chrome`, `firefox`, or `webkit`.
+
 For detailed installation and configuration instructions, please refer to the platform-specific guides:
 
 - [**Android**](/docs/platforms/android)

--- a/website/src/docs/platforms/web.mdx
+++ b/website/src/docs/platforms/web.mdx
@@ -53,6 +53,7 @@ Harness supports all major browser engines through helper factories.
 | `headless`       | `boolean` | `true`  | Whether to run the browser in headless mode.      |
 | `channel`        | `string`  | -       | Browser channel (e.g., `'chrome'`, `'msedge'`).   |
 | `executablePath` | `string`  | -       | Path to a specific browser binary on your system. |
+| `ignoreDefaultArgs` | `boolean` or `string[]` | - | Ignore Playwright's default launch arguments, or remove specific ones. |
 
 ## UI Testing on Web
 


### PR DESCRIPTION
## Summary
- Adds `ignoreDefaultArgs` to `WebBrowserConfigSchema`, accepting either `boolean` or `string[]` to match Playwright's [`LaunchOptions.ignoreDefaultArgs`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-ignore-default-args).
- Forwards the value into `browserType.launch()` in the web runner so users can disable Playwright's defaults (e.g. drop `--enable-automation`) or strip individual default args without having to fork the runner.

## Motivation
Some test setups need to disable specific Playwright defaults (for example to keep `--enable-automation` off so DRM / EME stacks behave the same way they do in a real browser, or to opt out of Playwright's headless-shell args). Without this option the only workaround is to wrap the platform and re-implement the launch flow.

## Test plan
- [x] `nx run @react-native-harness/platform-web:typecheck` passes
- [ ] Run a web target with `ignoreDefaultArgs: true` and confirm the browser launches without Playwright's defaults
- [ ] Run a web target with `ignoreDefaultArgs: ['--enable-automation']` and confirm only that flag is stripped