### PR TITLE
fix(runtime): don't overwrite native Event/EventTarget on web

### DIFF
--- a/.nx/version-plans/version-plan-1779082548000.md
+++ b/.nx/version-plans/version-plan-1779082548000.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness now keeps the browser's native `Event` and `EventTarget` on web, while still applying the shim where React Native needs it, so web users no longer lose native DOM behavior.

--- a/packages/runtime/src/initialize.ts
+++ b/packages/runtime/src/initialize.ts
@@ -3,10 +3,19 @@ import { getClient } from './client/index.js';
 import { disableHMRWhenReady } from './disableHMRWhenReady.js';
 import { setupJestMock } from './jest-mock.js';
 
-// Polyfill for EventTarget
+// Polyfill for EventTarget on runtimes that don't ship one (RN's JSC).
+// Do NOT overwrite when a native ctor already exists (RN Web / browsers):
+// Safari's EventTarget.dispatchEvent() does an internal brand check and
+// rejects polyfill instances with a TypeError, which breaks any
+// DOM-event-driven flow in the page — most visibly DRM (FairPlay) via
+// libraries that re-dispatch synthetic `encrypted` events.
 const Shim = require('event-target-shim');
-globalThis.Event = Shim.Event;
-globalThis.EventTarget = Shim.EventTarget;
+if (typeof globalThis.Event !== 'function') {
+  globalThis.Event = Shim.Event;
+}
+if (typeof globalThis.EventTarget !== 'function') {
+  globalThis.EventTarget = Shim.EventTarget;
+}
 
 // Setup jest mock to warn users about using Jest APIs
 setupJestMock();


### PR DESCRIPTION
## Summary

`@react-native-harness/runtime`'s `initialize.ts` unconditionally assigns `event-target-shim`'s classes to `globalThis.Event` and `globalThis.EventTarget`. That polyfill is required on RN's JavaScriptCore runtime (which has no DOM), but on web (RN Web running in a real browser) it clobbers the browser's native ctors.

Safari's native `EventTarget.dispatchEvent()` does an internal brand check on its argument and throws

> `TypeError: Argument 1 ('event') to EventTarget.dispatchEvent must be an instance of Event`

when a polyfill instance is dispatched onto a native `EventTarget` — even though the polyfill behaves mostly like `Event`. That's enough to break any DOM-event-driven flow in the page.

## Fix

Only install the polyfill when a native ctor is not already present:

```ts
if (typeof globalThis.Event !== 'function') {
  globalThis.Event = Shim.Event;
}
if (typeof globalThis.EventTarget !== 'function') {
  globalThis.EventTarget = Shim.EventTarget;
}
```

- On RN/JSC: `typeof globalThis.Event !== 'function'`, polyfill installs — unchanged behaviour.
- On RN Web / any browser: `Event` is a native ctor, polyfill is skipped, native dispatch keeps working.

## Test plan

- [x] `pnpm nx run-many -t build typecheck lint -p @react-native-harness/runtime` — green.
