### PR TITLE
fix(bridge): close rpc on disconnect

### DIFF
--- a/.changeset/bridge-close-rpc-on-disconnect.md
+++ b/.changeset/bridge-close-rpc-on-disconnect.md
@@ -1,0 +1,5 @@
+---
+'@react-native-harness/bridge': patch
+---
+
+Close the bridge RPC channel as soon as the app WebSocket disconnects so in-flight calls fail immediately instead of waiting for a timeout. This makes bridge shutdowns easier to detect and gives higher layers a faster, more accurate signal when the app session disappears.

--- a/packages/bridge/src/server.ts
+++ b/packages/bridge/src/server.ts
@@ -140,6 +140,8 @@ export const createHarnessBridge = async (
   wss.on('connection', (ws: WebSocket) => {
     bridgeLogger.debug('app connected');
     const binaryStore = new BinaryStore();
+    let readyConnection: AppConnection | null = null;
+    let disconnected = false;
 
     const serverFunctions: BridgeServerFunctions = {
       reportReady: (device) => {
@@ -147,6 +149,7 @@ export const createHarnessBridge = async (
           device,
           runTests: (testPath, opts) => rpc.runTests(testPath, opts),
         };
+        readyConnection = conn;
         currentConnection = conn;
         bridgeLogger.debug(
           'app ready: platform=%s model=%s',
@@ -209,11 +212,25 @@ export const createHarnessBridge = async (
       },
     );
 
-    ws.on('close', () => {
+    const disconnect = (reason?: Error) => {
+      if (disconnected) return;
+      disconnected = true;
+
       bridgeLogger.debug('app disconnected');
       binaryStore.dispose();
-      currentConnection = null;
+      if (currentConnection === readyConnection) {
+        currentConnection = null;
+      }
+      rpc.$close(reason ?? new Error('App bridge disconnected'));
       emitter.emit('disconnected');
+    };
+
+    ws.on('close', () => {
+      disconnect();
+    });
+
+    ws.on('error', (error) => {
+      disconnect(error instanceof Error ? error : new Error('App bridge socket error'));
     });
   });
 


### PR DESCRIPTION
## Description

Close the bridge RPC channel when the app WebSocket closes so in-flight RPC calls fail immediately instead of waiting for a timeout.

## Related Issue

None.

## Context

The bridge already observes app socket disconnects, but pending birpc calls were left alive until timeout. Closing the RPC channel on disconnect gives higher layers a faster and more accurate signal that the app session is gone, which is especially useful when the app crashes or drops the bridge unexpectedly.