### PR TITLE
feat(jest): emit per-test case events

### DIFF
--- a/.nx/version-plans/version-plan-1779970022000.md
+++ b/.nx/version-plans/version-plan-1779970022000.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness test events now include richer per-test context, so end-users can skip or react to individual tests more reliably and get clearer pass/fail reporting from the runner.

--- a/packages/bridge/src/shared/test-collector.ts
+++ b/packages/bridge/src/shared/test-collector.ts
@@ -2,6 +2,8 @@ import type { HarnessTestContext } from './test-context.js';
 
 export type TestStatus = 'active' | 'skipped' | 'todo';
 
+export type TestDeclarationMode = 'only' | 'skip' | 'todo';
+
 export type TestFn = (context: HarnessTestContext) => void | Promise<void>;
 
 export type SuiteHookFn = () => void | Promise<void>;
@@ -10,6 +12,7 @@ export type TestCase = {
   name: string;
   fn: TestFn;
   status: TestStatus;
+  declarationMode?: TestDeclarationMode;
 };
 
 export type TestSuite = {

--- a/packages/bridge/src/shared/test-runner.ts
+++ b/packages/bridge/src/shared/test-runner.ts
@@ -1,3 +1,5 @@
+import type { TestDeclarationMode } from './test-collector.js';
+
 export type CodeFrame = {
   content: string;
   location?: {
@@ -37,6 +39,10 @@ export type TestRunnerTestStartedEvent = {
   name: string;
   suite: string;
   file: string;
+  ancestorTitles: string[];
+  fullName: string;
+  startedAt: number;
+  declarationMode?: TestDeclarationMode;
 };
 
 export type TestRunnerTestFinishedEvent = {
@@ -44,6 +50,10 @@ export type TestRunnerTestFinishedEvent = {
   name: string;
   suite: string;
   file: string;
+  ancestorTitles: string[];
+  fullName: string;
+  startedAt: number;
+  declarationMode?: TestDeclarationMode;
   duration: number;
   error?: SerializedError;
   status: TestResultStatus;
@@ -71,6 +81,10 @@ export type TestResult = {
   status: TestResultStatus;
   error?: SerializedError;
   duration: number;
+  ancestorTitles?: string[];
+  fullName?: string;
+  startedAt?: number;
+  declarationMode?: TestDeclarationMode;
 };
 
 export type TestSuiteResult = {

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Config, Test, TestWatcher } from 'jest-runner';
 import type { TestResult as JestTestResult } from '@jest/test-result';
-import type { TestSuiteResult } from '@react-native-harness/bridge';
+import type {
+  TestRunnerTestFinishedEvent,
+  TestRunnerTestStartedEvent,
+  TestSuiteResult,
+} from '@react-native-harness/bridge';
 import { NativeCrashError, StartupStallError } from '../errors.js';
 import { DeviceNotRespondingError } from '@react-native-harness/bridge/server';
 import type { HarnessSession } from '../harness-session.js';
 import { executeRun } from '../execute-run.js';
+
+type EmitEvent = Parameters<typeof executeRun>[3];
+type RecordedEmitEvent = {
+  emitEvent: EmitEvent;
+  calls: Array<unknown[]>;
+};
 
 const resolveUndefined = async () => undefined;
 
@@ -93,10 +103,20 @@ const makeSession = (overrides: Partial<HarnessSession> = {}): HarnessSession =>
   resetCrashState: vi.fn(),
   flushClientLogs: vi.fn(() => []),
   callHook: vi.fn(resolveUndefined),
+  onTestRunnerEvent: vi.fn(() => () => undefined),
   setRunState: vi.fn(),
   dispose: vi.fn(resolveUndefined),
   ...overrides,
 });
+
+const makeEmitEvent = (): RecordedEmitEvent => {
+  const calls: Array<unknown[]> = [];
+  const emitEvent: EmitEvent = (async (...eventData) => {
+    calls.push(eventData);
+  }) as EmitEvent;
+
+  return { emitEvent, calls };
+};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -115,7 +135,7 @@ describe('executeRun', () => {
         callHook: vi.fn(async (name) => { hookNames.push(name as string); }),
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       expect(hookNames[0]).toBe('run:started');
       expect(hookNames[hookNames.length - 1]).toBe('run:finished');
@@ -127,7 +147,7 @@ describe('executeRun', () => {
         callHook: vi.fn(async (name) => { hookNames.push(name as string); }),
       });
 
-      await executeRun(session, [makeTest('/a.ts'), makeTest('/b.ts')], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest('/a.ts'), makeTest('/b.ts')], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       const fileHooks = hookNames.filter((n) =>
         n === 'test-file:started' || n === 'test-file:finished',
@@ -145,29 +165,41 @@ describe('executeRun', () => {
         ensureAppReady: vi.fn(async () => { throw new Error('unexpected'); }),
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       expect(hookNames).toContain('run:finished');
     });
   });
 
   describe('happy path', () => {
-    it('calls onStart, ensureAppReady, runTestFile, onResult in order', async () => {
+    it('emits file start, ensureAppReady, runTestFile, file success in order', async () => {
       const order: string[] = [];
       const session = makeSession({
         ensureAppReady: vi.fn(async () => { order.push('ensureAppReady'); }),
       });
-      const onStart = vi.fn(async () => { order.push('onStart'); });
-      const onResult = vi.fn(async () => { order.push('onResult'); });
+      const emitEvent: EmitEvent = (async (eventName, ..._eventData) => {
+        if (eventName === 'test-file-start') {
+          order.push('test-file-start');
+        }
+
+        if (eventName === 'test-file-success') {
+          order.push('test-file-success');
+        }
+      }) as EmitEvent;
 
       mockRunHarnessTestFile.mockImplementation(async () => {
         order.push('runTestFile');
         return makeFileRunResult();
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), onStart, onResult, vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), emitEvent, makeGlobalConfig());
 
-      expect(order).toEqual(['onStart', 'ensureAppReady', 'runTestFile', 'onResult']);
+      expect(order).toEqual([
+        'test-file-start',
+        'ensureAppReady',
+        'runTestFile',
+        'test-file-success',
+      ]);
     });
 
     it('accumulates passing test counts in run:finished summary', async () => {
@@ -182,7 +214,7 @@ describe('executeRun', () => {
         makeFileRunResult({ jestResult: makeJestResult({ numPassingTests: 3 }) }),
       );
 
-      await executeRun(session, [makeTest(), makeTest('/b.ts')], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest(), makeTest('/b.ts')], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       const payload = finishedPayload as { summary: { passed: number }; status: string };
       expect(payload.summary.passed).toBe(6);
@@ -196,55 +228,126 @@ describe('executeRun', () => {
           .mockReturnValueOnce([])
           .mockReturnValueOnce(clientLogs),
       });
-      const onResult = vi.fn();
+      const { emitEvent, calls } = makeEmitEvent();
 
       await executeRun(
         session,
         [makeTest()],
         makeWatcher(),
-        vi.fn(),
-        onResult,
-        vi.fn(),
+        emitEvent,
         makeGlobalConfig(),
       );
 
       expect(session.flushClientLogs).toHaveBeenCalledTimes(2);
-      expect(onResult).toHaveBeenCalledWith(
+      expect(calls).toContainEqual([
+        'test-file-success',
         expect.anything(),
         expect.objectContaining({ console: clientLogs }),
-      );
+      ]);
+    });
+
+    it('emits test-case events before file success', async () => {
+      let testRunnerListener:
+        | ((event: TestRunnerTestStartedEvent | TestRunnerTestFinishedEvent) => void)
+        | undefined;
+      const { emitEvent, calls: emittedEvents } = makeEmitEvent();
+      const session = makeSession({
+        onTestRunnerEvent: vi.fn((listener) => {
+          testRunnerListener = listener as typeof testRunnerListener;
+          return () => undefined;
+        }),
+      });
+
+      mockRunHarnessTestFile.mockImplementation(async () => {
+        testRunnerListener?.({
+          type: 'test-started',
+          file: 'example.ts',
+          suite: 'suite',
+          name: 'works',
+          ancestorTitles: ['suite'],
+          fullName: 'suite works',
+          startedAt: 10,
+          declarationMode: 'only',
+        });
+        testRunnerListener?.({
+          type: 'test-finished',
+          file: 'example.ts',
+          suite: 'suite',
+          name: 'works',
+          ancestorTitles: ['suite'],
+          fullName: 'suite works',
+          startedAt: 10,
+          declarationMode: 'only',
+          duration: 5,
+          status: 'passed',
+        });
+
+        return makeFileRunResult();
+      });
+
+      await executeRun(session, [makeTest()], makeWatcher(), emitEvent, makeGlobalConfig());
+
+      expect(emittedEvents).toEqual([
+        ['test-file-start', expect.anything()],
+        [
+          'test-case-start',
+          'example.ts',
+          expect.objectContaining({
+            ancestorTitles: ['suite'],
+            fullName: 'suite works',
+            mode: 'only',
+            title: 'works',
+            startedAt: 10,
+          }),
+        ],
+        [
+          'test-case-result',
+          'example.ts',
+          expect.objectContaining({
+            ancestorTitles: ['suite'],
+            fullName: 'suite works',
+            numPassingAsserts: 1,
+            startedAt: 10,
+            status: 'passed',
+            title: 'works',
+          }),
+        ],
+        ['test-file-success', expect.anything(), expect.anything()],
+      ]);
     });
   });
 
   describe('runtime failures', () => {
     it('passes StartupStallError to onFailure with an empty stack', async () => {
-      const onFailure = vi.fn();
+      const { emitEvent, calls } = makeEmitEvent();
       const session = makeSession({
         ensureAppReady: vi.fn().mockRejectedValue(new StartupStallError(1500, 3)),
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), onFailure, makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), emitEvent, makeGlobalConfig());
 
-      expect(onFailure).toHaveBeenCalledWith(
+      expect(calls).toContainEqual([
+        'test-file-failure',
         expect.objectContaining({ path: '/test/example.ts' }),
         expect.objectContaining({ message: expect.stringContaining('1500'), stack: '' }),
-      );
+      ]);
     });
 
     it('passes DeviceNotRespondingError to onFailure with an empty stack', async () => {
-      const onFailure = vi.fn();
+      const { emitEvent, calls } = makeEmitEvent();
       const session = makeSession({
         ensureAppReady: vi.fn().mockRejectedValue(
           new DeviceNotRespondingError('runTests', []),
         ),
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), onFailure, makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), emitEvent, makeGlobalConfig());
 
-      expect(onFailure).toHaveBeenCalledWith(
+      expect(calls).toContainEqual([
+        'test-file-failure',
         expect.anything(),
         expect.objectContaining({ stack: '' }),
-      );
+      ]);
     });
 
     it('calls resetCrashState after a NativeCrashError', async () => {
@@ -254,7 +357,7 @@ describe('executeRun', () => {
         ),
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       expect(session.resetCrashState).toHaveBeenCalled();
     });
@@ -268,7 +371,7 @@ describe('executeRun', () => {
         ensureAppReady: vi.fn().mockRejectedValue(new StartupStallError(1000, 2)),
       });
 
-      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeGlobalConfig());
+      await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       const payload = finishedPayload as { summary: { failed: number }; status: string };
       expect(payload.summary.failed).toBe(1);
@@ -282,20 +385,18 @@ describe('executeRun', () => {
       const session = makeSession({
         callHook: vi.fn(async (name) => { hookNames.push(name as string); }),
       });
-      const onStart = vi.fn();
+      const { emitEvent, calls } = makeEmitEvent();
 
       await executeRun(
         session,
         [makeTest('/a.ts'), makeTest('/b.ts')],
         makeWatcher(true /* interrupted */),
-        onStart,
-        vi.fn(),
-        vi.fn(),
+        emitEvent,
         makeGlobalConfig(),
       );
 
       // No test was started; watcher was already interrupted.
-      expect(onStart).not.toHaveBeenCalled();
+      expect(calls).not.toContainEqual(['test-file-start', expect.anything()]);
       expect(hookNames).toContain('run:finished');
     });
   });
@@ -314,7 +415,7 @@ describe('executeRun', () => {
         session,
         [makeTest('/a.ts'), makeTest('/b.ts'), makeTest('/c.ts')],
         makeWatcher(),
-        vi.fn(), vi.fn(), vi.fn(),
+        makeEmitEvent().emitEvent,
         makeGlobalConfig(),
       );
 

--- a/packages/jest/src/__tests__/index.test.ts
+++ b/packages/jest/src/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import type { Config, Test, TestRunnerOptions, TestWatcher } from 'jest-runner';
+import type { Config, Test, TestEvents, TestRunnerOptions, TestWatcher } from 'jest-runner';
 import type { TestSuiteResult } from '@react-native-harness/bridge';
 import type { HarnessSession } from '../harness-session.js';
+import type { executeRun as ExecuteRun } from '../execute-run.js';
 import { HarnessError } from '@react-native-harness/tools';
 import JestHarness from '../index.js';
 
@@ -14,6 +15,7 @@ const resolveUndefined = async () => undefined;
 const mockSession: HarnessSession = {
   config: { metroPort: 8081 } as HarnessSession['config'],
   context: {} as HarnessSession['context'],
+  onTestRunnerEvent: vi.fn(() => () => undefined),
   ensureAppReady: vi.fn(resolveUndefined),
   runTestFile: vi.fn(async (): Promise<TestSuiteResult> => ({
     name: '',
@@ -55,6 +57,41 @@ const makeTest = (): Test => ({
 const makeGlobalConfig = (overrides: Partial<Config.GlobalConfig> = {}): Config.GlobalConfig =>
   ({ rootDir: '/project', watch: false, watchAll: false, collectCoverage: false, ...overrides } as Config.GlobalConfig);
 
+type ExecuteRunMock = typeof ExecuteRun;
+type TypedExecuteRunMock = typeof mockExecuteRun & {
+  mockImplementationOnce: (implementation: ExecuteRunMock) => typeof mockExecuteRun;
+  mockResolvedValue: (value: Awaited<ReturnType<ExecuteRunMock>>) => typeof mockExecuteRun;
+};
+type ExecuteRunParams = Parameters<ExecuteRunMock>;
+
+const typedMockExecuteRun = mockExecuteRun as TypedExecuteRunMock;
+
+const makeTestCaseStartPayload = (): TestEvents['test-case-start'] => [
+  '/test/example.ts',
+  {
+    ancestorTitles: [],
+    fullName: 'suite case',
+    mode: undefined,
+    title: 'case',
+    startedAt: 1,
+  },
+];
+
+const makeTestCaseResultPayload = (): TestEvents['test-case-result'] => [
+  '/test/example.ts',
+  {
+    ancestorTitles: [],
+    duration: 1,
+    failureDetails: [],
+    failureMessages: [],
+    fullName: 'suite case',
+    numPassingAsserts: 1,
+    startedAt: 1,
+    status: 'passed',
+    title: 'case',
+  },
+];
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -62,7 +99,7 @@ const makeGlobalConfig = (overrides: Partial<Config.GlobalConfig> = {}): Config.
 beforeEach(() => {
   vi.clearAllMocks();
   (mockSession.dispose as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
-  mockExecuteRun.mockResolvedValue(undefined);
+  typedMockExecuteRun.mockResolvedValue(undefined);
   mockCreateHarnessSession.mockResolvedValue(mockSession);
 });
 
@@ -71,7 +108,7 @@ describe('JestHarness', () => {
     it('creates a session on the first run', async () => {
       const runner = new JestHarness(makeGlobalConfig());
 
-      await runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions());
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
 
       expect(mockCreateHarnessSession).toHaveBeenCalledOnce();
     });
@@ -79,8 +116,8 @@ describe('JestHarness', () => {
     it('reuses the session across runs in watch mode', async () => {
       const runner = new JestHarness(makeGlobalConfig({ watch: true }));
 
-      await runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions());
-      await runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions());
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
 
       expect(mockCreateHarnessSession).toHaveBeenCalledOnce();
       expect(mockSession.dispose).not.toHaveBeenCalled();
@@ -89,7 +126,7 @@ describe('JestHarness', () => {
     it('disposes the session after each run in normal mode', async () => {
       const runner = new JestHarness(makeGlobalConfig());
 
-      await runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions());
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
 
       expect(mockSession.dispose).toHaveBeenCalledOnce();
     });
@@ -97,10 +134,51 @@ describe('JestHarness', () => {
     it('creates a fresh session for each run in normal mode', async () => {
       const runner = new JestHarness(makeGlobalConfig());
 
-      await runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions());
-      await runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions());
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
 
       expect(mockCreateHarnessSession).toHaveBeenCalledTimes(2);
+    });
+
+    it('emits registered Jest events', async () => {
+      const runner = new JestHarness(makeGlobalConfig());
+      const listener = vi.fn();
+      const eventPayload = makeTestCaseStartPayload();
+
+      runner.on('test-case-start', listener);
+      typedMockExecuteRun.mockImplementationOnce(async (
+        _session: ExecuteRunParams[0],
+        _tests: ExecuteRunParams[1],
+        _watcher: ExecuteRunParams[2],
+        emitEvent: ExecuteRunParams[3],
+      ) => {
+        await emitEvent('test-case-start', ...eventPayload);
+      });
+
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
+
+      expect(listener).toHaveBeenCalledWith(eventPayload);
+    });
+
+    it('stops emitting after listener unsubscribe', async () => {
+      const runner = new JestHarness(makeGlobalConfig());
+      const listener = vi.fn();
+      const unsubscribe = runner.on('test-case-result', listener);
+      const eventPayload = makeTestCaseResultPayload();
+
+      unsubscribe();
+      typedMockExecuteRun.mockImplementationOnce(async (
+        _session: ExecuteRunParams[0],
+        _tests: ExecuteRunParams[1],
+        _watcher: ExecuteRunParams[2],
+        emitEvent: ExecuteRunParams[3],
+      ) => {
+        await emitEvent('test-case-result', ...eventPayload);
+      });
+
+      await runner.runTests([makeTest()], makeWatcher(), makeOptions());
+
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 
@@ -115,7 +193,7 @@ describe('JestHarness', () => {
       const runner = new JestHarness(makeGlobalConfig());
 
       await expect(
-        runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions()),
+        runner.runTests([makeTest()], makeWatcher(), makeOptions()),
       ).rejects.toBeTypeOf('string');
     });
 
@@ -126,7 +204,7 @@ describe('JestHarness', () => {
       const runner = new JestHarness(makeGlobalConfig());
 
       await expect(
-        runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), makeOptions()),
+        runner.runTests([makeTest()], makeWatcher(), makeOptions()),
       ).rejects.toBe(cause);
     });
 
@@ -134,7 +212,7 @@ describe('JestHarness', () => {
       const runner = new JestHarness(makeGlobalConfig());
 
       await expect(
-        runner.runTests([makeTest()], makeWatcher(), vi.fn(), vi.fn(), vi.fn(), { serial: false }),
+        runner.runTests([makeTest()], makeWatcher(), { serial: false }),
       ).rejects.toThrow('Parallel test running is not supported');
     });
   });

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -1,10 +1,8 @@
 import type {
-  OnTestFailure,
-  OnTestStart,
-  OnTestSuccess,
   Test,
   TestWatcher,
   Config,
+  TestEvents,
 } from 'jest-runner';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
@@ -15,6 +13,17 @@ import {
   StartupStallError,
 } from './errors.js';
 import { DeviceNotRespondingError } from '@react-native-harness/bridge/server';
+import type { TestCaseResult } from '@jest/test-result';
+import type {
+  TestRunnerEvents,
+  TestRunnerTestFinishedEvent,
+  TestRunnerTestStartedEvent,
+} from '@react-native-harness/bridge';
+
+type EmitTestEvent = <Name extends keyof TestEvents>(
+  eventName: Name,
+  ...eventData: TestEvents[Name]
+) => Promise<void>;
 
 const createRunSummary = () => ({ passed: 0, failed: 0, skipped: 0, todo: 0 });
 
@@ -46,13 +55,60 @@ const buildTestFailure = (err: unknown): { message: string; stack: string } => {
   return err as { message: string; stack: string };
 };
 
+const toJestMode = (
+  declarationMode?: 'only' | 'skip' | 'todo',
+): 'only' | 'skip' | 'todo' | undefined => declarationMode;
+
+const emitHarnessTestStarted = async (
+  emitEvent: EmitTestEvent,
+  event: TestRunnerTestStartedEvent,
+): Promise<void> => {
+  await emitEvent('test-case-start', event.file, {
+    ancestorTitles: event.ancestorTitles,
+    fullName: event.fullName,
+    mode: toJestMode(event.declarationMode),
+    title: event.name,
+    startedAt: event.startedAt,
+  });
+};
+
+const emitHarnessTestFinished = async (
+  emitEvent: EmitTestEvent,
+  event: TestRunnerTestFinishedEvent,
+): Promise<void> => {
+  const failureMessage = event.error?.message;
+  const codeFrame = event.error?.codeFrame;
+  const location = codeFrame?.location
+    ? { column: codeFrame.location.column, line: codeFrame.location.row }
+    : null;
+  const testCaseResult: TestCaseResult = {
+    ancestorTitles: event.ancestorTitles,
+    duration: event.duration,
+    failureDetails: [],
+    failureMessages: failureMessage
+      ? [`${failureMessage}${codeFrame ? `\n\n${codeFrame.content}` : ''}`]
+      : [],
+    fullName: event.fullName,
+    location,
+    numPassingAsserts: event.status === 'passed' ? 1 : 0,
+    startedAt: event.startedAt,
+    status: event.status,
+    title: event.name,
+  };
+
+  await emitEvent('test-case-result', event.file, testCaseResult);
+};
+
+const isHarnessCaseEvent = (
+  event: TestRunnerEvents,
+): event is TestRunnerTestStartedEvent | TestRunnerTestFinishedEvent =>
+  event.type === 'test-started' || event.type === 'test-finished';
+
 export const executeRun = async (
   session: HarnessSession,
   tests: Array<Test>,
   watcher: TestWatcher,
-  onStart: OnTestStart,
-  onResult: OnTestSuccess,
-  onFailure: OnTestFailure,
+  emitEvent: EmitTestEvent,
   globalConfig: Config.GlobalConfig,
 ): Promise<void> => {
   const runId = randomUUID();
@@ -61,6 +117,16 @@ export const executeRun = async (
   const rootDir = globalConfig.rootDir ?? process.cwd();
   const testFiles = tests.map((t) => path.relative(rootDir, t.path));
   const summary = createRunSummary();
+  let caseEventChain = Promise.resolve();
+  const unsubscribe = session.onTestRunnerEvent((event) => {
+    if (isHarnessCaseEvent(event)) {
+      caseEventChain = caseEventChain.then(() =>
+        event.type === 'test-started'
+          ? emitHarnessTestStarted(emitEvent, event)
+          : emitHarnessTestFinished(emitEvent, event),
+      );
+    }
+  });
 
   const updateRunState = (overrides: Partial<HarnessRunState> = {}) => {
     const state: HarnessRunState = {
@@ -128,7 +194,7 @@ export const executeRun = async (
         isFirstTest = false;
 
         session.flushClientLogs();
-        await onStart(test);
+        await emitEvent('test-file-start', test);
         await session.ensureAppReady(test.path);
 
         // Crash detection is handled inside session.runTestFile; NativeCrashError
@@ -151,7 +217,8 @@ export const executeRun = async (
           duration: result.duration,
           result: result.harnessResult,
         });
-        await onResult(test, result.jestResult);
+        await caseEventChain;
+        await emitEvent('test-file-success', test, result.jestResult);
       } catch (err) {
         if (!emittedTestFileFinished) {
           await emitTestFileFinished({
@@ -176,7 +243,8 @@ export const executeRun = async (
         }
 
         updateRunState({ error: isRuntimeFailure ? undefined : err });
-        onFailure(test, buildTestFailure(err));
+        await caseEventChain;
+        await emitEvent('test-file-failure', test, buildTestFailure(err));
       }
     }
   } catch (err) {
@@ -195,5 +263,7 @@ export const executeRun = async (
       status: runState.status ?? (runError != null ? 'failed' : 'passed'),
       ...(runError != null ? { error: runError } : {}),
     });
+    await caseEventChain;
+    unsubscribe();
   }
 };

--- a/packages/jest/src/harness-session.ts
+++ b/packages/jest/src/harness-session.ts
@@ -7,6 +7,7 @@ import {
   HARNESS_BRIDGE_PATH,
   type HarnessContext,
   type BridgeEvents,
+  type TestRunnerEvents,
   type TestExecutionOptions,
   type TestSuiteResult,
 } from '@react-native-harness/bridge';
@@ -92,6 +93,7 @@ export type HarnessRunTestsOptions = Exclude<TestExecutionOptions, 'platform'>;
 export type HarnessSession = {
   readonly config: HarnessConfig;
   readonly context: HarnessContext;
+  onTestRunnerEvent: (listener: (event: TestRunnerEvents) => void) => () => void;
   runTestFile: (path: string, options: HarnessRunTestsOptions) => Promise<TestSuiteResult>;
   ensureAppReady: (testFilePath: string) => Promise<void>;
   restartApp: (testFilePath?: string) => Promise<void>;
@@ -497,6 +499,19 @@ export const createHarnessSession = async (
     const flushClientLogs = (): ClientLogBuffer => clientLogCollector.flush();
 
     const clientLogListener = clientLogCollector.handleEvent;
+    const testRunnerEventListeners = new Set<(event: TestRunnerEvents) => void>();
+    const onTestRunnerEvent = (event: BridgeEvents) => {
+      if (
+        event.type === 'test-started' ||
+        event.type === 'test-finished' ||
+        event.type === 'suite-started' ||
+        event.type === 'suite-finished' ||
+        event.type === 'file-started' ||
+        event.type === 'file-finished'
+      ) {
+        testRunnerEventListeners.forEach((listener) => listener(event));
+      }
+    };
 
     const onConnected = (conn: AppConnection) => {
       const runId = getCurrentRunId();
@@ -513,6 +528,7 @@ export const createHarnessSession = async (
     bridge.on('connected', onConnected);
     bridge.on('disconnected', onDisconnected);
     bridge.on('event', bridgeEventListener);
+    bridge.on('event', onTestRunnerEvent);
     metroInstance.events.addListener(onMetroEvent);
     if (runtimeConfig.forwardClientLogs) {
       metroInstance.events.addListener(clientLogListener);
@@ -557,6 +573,7 @@ export const createHarnessSession = async (
       bridge.off('connected', onConnected);
       bridge.off('disconnected', onDisconnected);
       bridge.off('event', bridgeEventListener);
+      bridge.off('event', onTestRunnerEvent);
 
       const nativeCoverageConfig = runtimeConfig.coverage?.native?.ios;
       if (nativeCoverageConfig?.pods?.length && platformInstance.collectNativeCoverage) {
@@ -706,6 +723,12 @@ export const createHarnessSession = async (
     return {
       config: runtimeConfig,
       context,
+      onTestRunnerEvent: (listener) => {
+        testRunnerEventListeners.add(listener);
+        return () => {
+          testRunnerEventListeners.delete(listener);
+        };
+      },
       runTestFile,
       ensureAppReady,
       restartApp,

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -1,10 +1,8 @@
 import type {
-  CallbackTestRunnerInterface,
   Config,
-  OnTestFailure,
-  OnTestStart,
-  OnTestSuccess,
+  EmittingTestRunnerInterface,
   Test,
+  TestEvents,
   TestRunnerOptions,
   TestWatcher,
 } from 'jest-runner';
@@ -13,22 +11,41 @@ import { executeRun } from './execute-run.js';
 import { HarnessError } from '@react-native-harness/tools';
 import { getErrorMessage } from './logs.js';
 
-export default class JestHarness implements CallbackTestRunnerInterface {
+type TestEventListener<Name extends keyof TestEvents> = (
+  eventData: TestEvents[Name],
+) => void | Promise<void>;
+
+export default class JestHarness implements EmittingTestRunnerInterface {
   readonly isSerial = true;
+  readonly supportsEventEmitters = true as const;
 
   #globalConfig: Config.GlobalConfig;
   #session: HarnessSession | null = null;
+  #listeners = new Map<keyof TestEvents, Set<TestEventListener<keyof TestEvents>>>();
 
   constructor(globalConfig: Config.GlobalConfig) {
     this.#globalConfig = globalConfig;
   }
 
+  on<Name extends keyof TestEvents>(
+    eventName: Name,
+    listener: TestEventListener<Name>,
+  ): () => void {
+    const listeners = this.#listeners.get(eventName) ?? new Set();
+    listeners.add(listener as TestEventListener<keyof TestEvents>);
+    this.#listeners.set(eventName, listeners);
+
+    return () => {
+      listeners.delete(listener as TestEventListener<keyof TestEvents>);
+      if (listeners.size === 0) {
+        this.#listeners.delete(eventName);
+      }
+    };
+  }
+
   async runTests(
     tests: Array<Test>,
     watcher: TestWatcher,
-    onStart: OnTestStart,
-    onResult: OnTestSuccess,
-    onFailure: OnTestFailure,
     options: TestRunnerOptions,
   ): Promise<void> {
     if (!options.serial) {
@@ -46,9 +63,7 @@ export default class JestHarness implements CallbackTestRunnerInterface {
         this.#session,
         tests,
         watcher,
-        onStart,
-        onResult,
-        onFailure,
+        this.#emit,
         this.#globalConfig,
       );
     } catch (error) {
@@ -63,4 +78,18 @@ export default class JestHarness implements CallbackTestRunnerInterface {
       }
     }
   }
+
+  #emit = async <Name extends keyof TestEvents>(
+    eventName: Name,
+    ...eventData: TestEvents[Name]
+  ): Promise<void> => {
+    const listeners = this.#listeners.get(eventName);
+    if (!listeners) {
+      return;
+    }
+
+    for (const listener of listeners) {
+      await listener(eventData);
+    }
+  };
 }

--- a/packages/jest/src/run.ts
+++ b/packages/jest/src/run.ts
@@ -111,6 +111,7 @@ export const runHarnessTestFile: RunHarnessTestFile = async ({
         ? `${errorMessage}${codeFrame ? `\n\n${codeFrame.content}` : ''}`
         : undefined,
       title: test.name,
+      fullName: test.fullName,
       status: test.status,
       location: codeFrame?.location
         ? { column: codeFrame.location.column, line: codeFrame.location.row }

--- a/packages/jest/src/toTestResult.ts
+++ b/packages/jest/src/toTestResult.ts
@@ -16,6 +16,7 @@ export type Options = {
     errorMessage?: string;
     testPath?: string;
     title?: string;
+    fullName?: string;
     status: Status;
     location?: {
       column: number;
@@ -72,8 +73,8 @@ const getTestResults = ({
       duration: test.duration,
       failureDetails: [],
       failureMessages: actualErrorMessage ? [actualErrorMessage] : [],
-      fullName: jestTestPath || test.testPath || '',
-      numPassingAsserts: test.errorMessage ? 1 : 0,
+      fullName: test.fullName || test.testPath || jestTestPath || '',
+      numPassingAsserts: test.status === 'passed' ? 1 : 0,
       status: test.status,
       title: test.title || '',
       location: test.location,

--- a/packages/runtime/src/__tests__/runner-context.test.ts
+++ b/packages/runtime/src/__tests__/runner-context.test.ts
@@ -439,6 +439,55 @@ describe('runner task context', () => {
     }
   });
 
+  it('returns skipped descendants for describe.skip()', async () => {
+    const collector = getTestCollector();
+    const runner = getTestRunner();
+
+    try {
+      const collection = await collector.collect(() => {
+        harnessDescribe.skip('Skipped Suite', () => {
+          harnessIt('skipped test', () => undefined);
+
+          harnessDescribe('Nested Suite', () => {
+            harnessIt('nested skipped test', () => undefined);
+          });
+        });
+      }, 'runtime/describe-skip-descendants.test.ts');
+
+      const result = await runner.run({
+        testSuite: collection.testSuite,
+        testFilePath: 'runtime/describe-skip-descendants.test.ts',
+        runner: 'ios',
+      });
+
+      expect(result.suites[0]).toMatchObject({
+        name: 'Skipped Suite',
+        status: 'skipped',
+        tests: [
+          {
+            name: 'skipped test',
+            status: 'skipped',
+          },
+        ],
+        suites: [
+          {
+            name: 'Nested Suite',
+            status: 'skipped',
+            tests: [
+              {
+                name: 'nested skipped test',
+                status: 'skipped',
+              },
+            ],
+          },
+        ],
+      });
+    } finally {
+      collector.dispose();
+      runner.dispose();
+    }
+  });
+
   it('runs onTestFailed when afterEach fails', async () => {
     const calls: string[] = [];
     const collector = getTestCollector();

--- a/packages/runtime/src/collector/functions.ts
+++ b/packages/runtime/src/collector/functions.ts
@@ -76,10 +76,19 @@ const convertRawTestCaseToTestCase = (
   rawTest: RawTestCase,
   suiteContext: { hasFocusedTests: boolean }
 ): TestCase => {
+  const declarationMode = rawTest.options.todo
+    ? 'todo'
+    : rawTest.options.skip
+      ? 'skip'
+      : rawTest.options.only
+        ? 'only'
+        : undefined;
+
   return {
     name: rawTest.name,
     fn: rawTest.fn,
     status: computeTestStatus(rawTest, suiteContext),
+    declarationMode,
   };
 };
 

--- a/packages/runtime/src/runner/runSuite.ts
+++ b/packages/runtime/src/runner/runSuite.ts
@@ -21,6 +21,55 @@ import {
   runOnTestFinished,
 } from './test-context.js';
 
+const getAncestorTitles = (suite: TestSuite): string[] => {
+  const ancestorTitles: string[] = [];
+  let currentSuite = suite.parent;
+
+  while (currentSuite) {
+    if (currentSuite.name !== 'root') {
+      ancestorTitles.unshift(currentSuite.name);
+    }
+    currentSuite = currentSuite.parent;
+  }
+
+  if (suite.name !== 'root') {
+    ancestorTitles.push(suite.name);
+  }
+
+  return ancestorTitles;
+};
+
+const getFullName = (ancestorTitles: string[], testName: string): string =>
+  [...ancestorTitles, testName].join(' ');
+
+const emitTestFinished = (
+  context: TestRunnerContext,
+  options: {
+    test: TestCase;
+    suite: TestSuite;
+    startedAt: number;
+    duration: number;
+    status: 'passed' | 'failed' | 'skipped' | 'todo';
+    error?: TestResult['error'];
+  },
+) => {
+  const ancestorTitles = getAncestorTitles(options.suite);
+
+  context.events.emit({
+    type: 'test-finished',
+    file: context.testFilePath,
+    suite: options.suite.name,
+    name: options.test.name,
+    ancestorTitles,
+    fullName: getFullName(ancestorTitles, options.test.name),
+    startedAt: options.startedAt,
+    declarationMode: options.test.declarationMode,
+    duration: options.duration,
+    error: options.error,
+    status: options.status,
+  });
+};
+
 declare global {
   var HARNESS_TEST_PATH: string;
 }
@@ -30,7 +79,7 @@ const runTest = async (
   suite: TestSuite,
   context: TestRunnerContext,
 ): Promise<TestResult> => {
-  const startTime = Date.now();
+  const startedAt = Date.now();
   const task: HarnessTaskContext = {
     name: test.name,
     type: 'test',
@@ -54,11 +103,16 @@ const runTest = async (
   );
 
   // Emit test-started event
+  const ancestorTitles = getAncestorTitles(suite);
   context.events.emit({
     type: 'test-started',
     name: test.name,
     suite: suite.name,
     file: context.testFilePath,
+    ancestorTitles,
+    fullName: getFullName(ancestorTitles, test.name),
+    startedAt,
+    declarationMode: test.declarationMode,
   });
 
   try {
@@ -67,14 +121,16 @@ const runTest = async (
         name: test.name,
         status: 'skipped' as const,
         duration: 0,
+        ancestorTitles,
+        fullName: getFullName(ancestorTitles, test.name),
+        startedAt,
+        declarationMode: test.declarationMode,
       };
 
-      // Emit test-finished event
-      context.events.emit({
-        type: 'test-finished',
-        name: test.name,
-        suite: suite.name,
-        file: context.testFilePath,
+      emitTestFinished(context, {
+        test,
+        suite,
+        startedAt,
         duration: 0,
         status: 'skipped',
       });
@@ -88,14 +144,16 @@ const runTest = async (
         name: test.name,
         status: 'todo' as const,
         duration: 0,
+        ancestorTitles,
+        fullName: getFullName(ancestorTitles, test.name),
+        startedAt,
+        declarationMode: test.declarationMode,
       };
 
-      // Emit test-finished event
-      context.events.emit({
-        type: 'test-finished',
-        name: test.name,
-        suite: suite.name,
-        file: context.testFilePath,
+      emitTestFinished(context, {
+        test,
+        suite,
+        startedAt,
         duration: 0,
         status: 'todo',
       });
@@ -127,7 +185,7 @@ const runTest = async (
       }
 
       if (didSkip) {
-        const duration = Date.now() - startTime;
+        const duration = Date.now() - startedAt;
 
         await runOnTestFinished(lifecycleState);
 
@@ -135,13 +193,16 @@ const runTest = async (
           name: test.name,
           status: 'skipped' as const,
           duration,
+          ancestorTitles,
+          fullName: getFullName(ancestorTitles, test.name),
+          startedAt,
+          declarationMode: test.declarationMode,
         };
 
-        context.events.emit({
-          type: 'test-finished',
-          file: context.testFilePath,
-          suite: suite.name,
-          name: test.name,
+        emitTestFinished(context, {
+          test,
+          suite,
+          startedAt,
           duration,
           status: 'skipped',
         });
@@ -155,20 +216,22 @@ const runTest = async (
       setCurrentExpectTestState(undefined);
     }
 
-    const duration = Date.now() - startTime;
+    const duration = Date.now() - startedAt;
 
     const result = {
       name: test.name,
       status: 'passed' as const,
       duration,
+      ancestorTitles,
+      fullName: getFullName(ancestorTitles, test.name),
+      startedAt,
+      declarationMode: test.declarationMode,
     };
 
-    // Emit test-finished event
-    context.events.emit({
-      type: 'test-finished',
-      file: context.testFilePath,
-      suite: suite.name,
-      name: test.name,
+    emitTestFinished(context, {
+      test,
+      suite,
+      startedAt,
       duration,
       status: 'passed',
     });
@@ -184,21 +247,23 @@ const runTest = async (
       suite.name,
       test.name,
     );
-    const duration = Date.now() - startTime;
+    const duration = Date.now() - startedAt;
 
     const result = {
       name: test.name,
       status: 'failed' as const,
       error: testError.toSerializedJSON(),
       duration,
+      ancestorTitles,
+      fullName: getFullName(ancestorTitles, test.name),
+      startedAt,
+      declarationMode: test.declarationMode,
     };
 
-    // Emit test-finished event
-    context.events.emit({
-      type: 'test-finished',
-      file: context.testFilePath,
-      suite: suite.name,
-      name: test.name,
+    emitTestFinished(context, {
+      test,
+      suite,
+      startedAt,
       duration,
       error: testError.toSerializedJSON(),
       status: 'failed',
@@ -223,10 +288,19 @@ export const runSuite = async (
 
   // Check if suite should be skipped or is todo
   if (suite.status === 'skipped') {
+    const testResults = await Promise.all(
+      suite.tests.map((test) => runTest({ ...test, status: 'skipped' }, suite, context)),
+    );
+    const suiteResults = await Promise.all(
+      suite.suites.map((childSuite) =>
+        runSuite({ ...childSuite, status: 'skipped' }, context),
+      ),
+    );
+
     const result = {
       name: suite.name,
-      tests: [],
-      suites: [],
+      tests: testResults,
+      suites: suiteResults,
       status: 'skipped' as const,
       duration: 0,
     };


### PR DESCRIPTION
## Summary
- migrate the harness Jest runner to Jest's event-emitting runner API
- emit per-test-case Jest events from harness runtime metadata and preserve skipped descendants in skipped suites
- fix final Jest assertion metadata propagation and add coverage for emitted events

## Testing
- pnpm vitest packages/jest/src/__tests__/index.test.ts packages/jest/src/__tests__/execute-run.test.ts packages/runtime/src/__tests__/runner-context.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
- pre-push hook: nx test + build