### PR TITLE
refactor(bridge): replace birpc with internal rpc transport

### DIFF
--- a/.nx/version-plans/improve-bridge-resilience.md
+++ b/.nx/version-plans/improve-bridge-resilience.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness now handles app bridge reloads, reconnects, disconnects, and dropped sockets more reliably during test runs. For Harness users, this means fewer stuck runs waiting on a dead RPC channel and clearer failures when the app reloads, crashes, or loses its bridge connection mid-test.

--- a/packages/bridge/eslint.config.mjs
+++ b/packages/bridge/eslint.config.mjs
@@ -8,7 +8,11 @@ export default [
       '@nx/dependency-checks': [
         'error',
         {
-          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}'],
+          ignoredDependencies: ['vite', 'vitest'],
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/src/**/__tests__/**',
+          ],
         },
       ],
     },

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@react-native-harness/platforms": "workspace:*",
     "@react-native-harness/tools": "workspace:*",
-    "birpc": "^2.4.0",
     "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "ssim.js": "^3.5.0",
@@ -39,7 +38,9 @@
   "devDependencies": {
     "@types/pixelmatch": "^5.2.6",
     "@types/pngjs": "^6.0.5",
-    "@types/ws": "^8.18.1"
+    "@types/ws": "^8.18.1",
+    "vite": "^7.2.2",
+    "vitest": "^3.2.4"
   },
   "license": "MIT"
 }

--- a/packages/bridge/src/__tests__/client.test.ts
+++ b/packages/bridge/src/__tests__/client.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { connectToHarness } from '../client.js';
+import type {
+  BridgeTransport,
+  BridgeTransportCloseEvent,
+  BridgeTransportMessage,
+  BridgeTransportState,
+} from '../transport.js';
+
+const createMockTransport = (initialState: BridgeTransportState = 'connecting') => {
+  let state = initialState;
+  const openListeners = new Set<() => void>();
+  const messageListeners = new Set<(message: BridgeTransportMessage) => void>();
+  const closeListeners = new Set<(event: BridgeTransportCloseEvent) => void>();
+  const errorListeners = new Set<(error: Error) => void>();
+  const sent: BridgeTransportMessage[] = [];
+
+  const transport: BridgeTransport = {
+    get state() {
+      return state;
+    },
+    send: (message) => {
+      sent.push(message);
+    },
+    close: (code = 1000, reason = '') => {
+      state = 'closed';
+      for (const listener of closeListeners) {
+        listener({ code, reason });
+      }
+    },
+    onOpen: (listener) => {
+      openListeners.add(listener);
+      return () => openListeners.delete(listener);
+    },
+    onMessage: (listener) => {
+      messageListeners.add(listener);
+      return () => messageListeners.delete(listener);
+    },
+    onClose: (listener) => {
+      closeListeners.add(listener);
+      return () => closeListeners.delete(listener);
+    },
+    onError: (listener) => {
+      errorListeners.add(listener);
+      return () => errorListeners.delete(listener);
+    },
+  };
+
+  return {
+    transport,
+    sent,
+    open: () => {
+      state = 'open';
+      for (const listener of openListeners) {
+        listener();
+      }
+    },
+    receive: (message: BridgeTransportMessage) => {
+      for (const listener of messageListeners) {
+        listener(message);
+      }
+    },
+    fail: (error: Error) => {
+      for (const listener of errorListeners) {
+        listener(error);
+      }
+    },
+  };
+};
+
+describe('connectToHarness transport injection', () => {
+  it('uses the injected transport instead of constructing a WebSocket', async () => {
+    const mockTransport = createMockTransport();
+    const handlePromise = connectToHarness(
+      'ws://unused',
+      { runTests: vi.fn() },
+      { transport: mockTransport.transport },
+    );
+
+    mockTransport.open();
+
+    const handle = await handlePromise;
+    handle.reportReady({
+      platform: 'ios',
+      manufacturer: 'Apple',
+      model: 'Injected',
+      osVersion: '18.0',
+    });
+
+    expect(mockTransport.sent).toHaveLength(1);
+    expect(mockTransport.sent[0]).toBeTypeOf('string');
+    expect(JSON.parse(mockTransport.sent[0] as string)).toMatchObject({
+      type: 'ready',
+      device: { model: 'Injected' },
+    });
+
+    handle.disconnect();
+  });
+});

--- a/packages/bridge/src/__tests__/heartbeat.test.ts
+++ b/packages/bridge/src/__tests__/heartbeat.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createHeartbeat } from '../heartbeat.js';
+
+describe('bridge heartbeat', () => {
+  it('sends pings and times out stale sessions', () => {
+    vi.useFakeTimers();
+
+    const sendPing = vi.fn();
+    const onTimeout = vi.fn();
+    createHeartbeat({
+      sendPing,
+      onTimeout,
+      intervalMs: 5,
+      timeoutMs: 10,
+    });
+
+    vi.advanceTimersByTime(5);
+    expect(sendPing).toHaveBeenCalledWith(1);
+
+    vi.advanceTimersByTime(10);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
+  it('clears the timeout when the matching pong arrives', () => {
+    vi.useFakeTimers();
+
+    const sendPing = vi.fn();
+    const onTimeout = vi.fn();
+    const heartbeat = createHeartbeat({
+      sendPing,
+      onTimeout,
+      intervalMs: 5,
+      timeoutMs: 10,
+    });
+
+    vi.advanceTimersByTime(5);
+    heartbeat.notifyPong(1);
+    vi.advanceTimersByTime(10);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    heartbeat.dispose();
+    vi.useRealTimers();
+  });
+});

--- a/packages/bridge/src/__tests__/protocol.test.ts
+++ b/packages/bridge/src/__tests__/protocol.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deserializeBridgeError,
+  parseBridgeMessage,
+  serializeBridgeError,
+  serializeBridgeMessage,
+} from '../protocol.js';
+
+describe('bridge protocol', () => {
+  it('round-trips invoke messages', () => {
+    const raw = serializeBridgeMessage({
+      type: 'invoke',
+      id: 1,
+      method: 'runTests',
+      args: ['example.ts', { runner: '/runner.js' }],
+    });
+
+    expect(parseBridgeMessage(raw)).toEqual({
+      type: 'invoke',
+      id: 1,
+      method: 'runTests',
+      args: ['example.ts', { runner: '/runner.js' }],
+    });
+  });
+
+  it('serializes and restores errors with metadata', () => {
+    const cause = new Error('inner');
+    const error = new TypeError('boom', { cause });
+    error.stack = 'stack trace';
+
+    const restored = deserializeBridgeError(serializeBridgeError(error));
+
+    expect(restored.name).toBe('TypeError');
+    expect(restored.message).toBe('boom');
+    expect(restored.stack).toBe('stack trace');
+    expect(restored.cause).toBe(cause);
+  });
+
+  it('serializes non-Error thrown values explicitly', () => {
+    expect(serializeBridgeError('boom')).toEqual({
+      name: 'NonErrorThrown',
+      message: 'boom',
+    });
+  });
+
+  it('rejects malformed messages', () => {
+    expect(() => parseBridgeMessage('{"type":"invoke","id":"1"}')).toThrow(
+      'Invalid bridge message: id must be a number',
+    );
+  });
+});

--- a/packages/bridge/src/__tests__/rpc-peer.test.ts
+++ b/packages/bridge/src/__tests__/rpc-peer.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRpcPeer } from '../rpc-peer.js';
+import type { BridgeEvents } from '../shared.js';
+import type { RpcTransport } from '../transport.js';
+
+type LocalMethods = {
+  add: (left: number, right: number) => Promise<number>;
+  fail: () => Promise<never>;
+};
+
+const createMockTransport = (): RpcTransport & { messages: string[] } => {
+  const messages: string[] = [];
+
+  return {
+    state: 'open',
+    messages,
+    send: (message) => {
+      messages.push(message);
+    },
+  };
+};
+
+describe('rpc-peer', () => {
+  it('resolves successful RPC calls', async () => {
+    let serverHandleMessage: ((message: string) => Promise<unknown>) | null = null;
+
+    const client = createRpcPeer<Record<string, never>, { add: LocalMethods['add'] }, BridgeEvents>({
+      localMethods: {},
+      transport: {
+        state: 'open',
+        send: (message) => {
+          if (!serverHandleMessage) {
+            throw new Error('Server peer not initialized');
+          }
+
+          void serverHandleMessage(message);
+        },
+      },
+    });
+
+    const server = createRpcPeer<LocalMethods, Record<string, never>, BridgeEvents>({
+      localMethods: {
+        add: async (left, right) => left + right,
+        fail: async () => {
+          throw new Error('unused');
+        },
+      },
+      transport: {
+        state: 'open',
+        send: (message) => {
+          void client.handleMessage(message);
+        },
+      },
+    });
+
+    serverHandleMessage = server.handleMessage;
+
+    const result = await client.invoke('add', 2, 3);
+
+    expect(result).toBe(5);
+  });
+
+  it('rejects failed RPC calls with restored errors', async () => {
+    const client = createRpcPeer<Record<string, never>, { fail: () => Promise<void> }, BridgeEvents>({
+      localMethods: {},
+      transport: createMockTransport(),
+    });
+
+    const server = createRpcPeer<
+      { fail: () => Promise<void> },
+      Record<string, never>,
+      BridgeEvents
+    >({
+      localMethods: {
+        fail: async () => {
+          throw new TypeError('boom');
+        },
+      },
+      transport: {
+        state: 'open',
+        send: (message) => {
+          void client.handleMessage(message);
+        },
+      },
+    });
+
+    await server.handleMessage(
+      JSON.stringify({ type: 'invoke', id: 1, method: 'fail', args: [] }),
+    );
+
+    await expect(client.handleMessage('{"type":"return","id":1,"ok":false,"error":{"name":"TypeError","message":"boom"}}')).resolves.toBeNull();
+  });
+
+  it('rejects unknown methods', async () => {
+    let response = '';
+    const peer = createRpcPeer<Record<string, never>, Record<string, never>, BridgeEvents>({
+      localMethods: {},
+      transport: {
+        state: 'open',
+        send: (message) => {
+          response = message;
+        },
+      },
+    });
+
+    await peer.handleMessage(
+      JSON.stringify({ type: 'invoke', id: 1, method: 'missing', args: [] }),
+    );
+
+    expect(JSON.parse(response)).toMatchObject({
+      type: 'return',
+      id: 1,
+      ok: false,
+    });
+  });
+
+  it('dispatches incoming events', async () => {
+    const onEvent = vi.fn();
+    const peer = createRpcPeer<Record<string, never>, Record<string, never>, BridgeEvents>({
+      localMethods: {},
+      transport: createMockTransport(),
+      onEvent,
+    });
+
+    await peer.handleMessage(
+      JSON.stringify({
+        type: 'event',
+        event: { type: 'collection-started', file: 'example.ts' },
+      }),
+    );
+
+    expect(onEvent).toHaveBeenCalledWith({
+      type: 'collection-started',
+      file: 'example.ts',
+    });
+  });
+
+  it('rejects pending calls when closed', async () => {
+    const peer = createRpcPeer<
+      Record<string, never>,
+      { runTests: (path: string, options: { runner: string }) => Promise<void> },
+      BridgeEvents
+    >({
+      localMethods: {},
+      transport: createMockTransport(),
+    });
+
+    const pending = peer.invoke('runTests', 'example.ts', { runner: '/runner.js' });
+    peer.close(new Error('closed'));
+
+    await expect(pending).rejects.toThrow('closed');
+  });
+
+  it('rejects pending calls on timeout', async () => {
+    const peer = createRpcPeer<
+      Record<string, never>,
+      { runTests: (path: string, options: { runner: string }) => Promise<void> },
+      BridgeEvents
+    >({
+      localMethods: {},
+      transport: createMockTransport(),
+      callTimeoutMs: 10,
+      createTimeoutError: () => new Error('timed out'),
+    });
+
+    const pending = peer.invoke('runTests', 'example.ts', { runner: '/runner.js' });
+
+    await expect(pending).rejects.toThrow('timed out');
+  });
+
+  it('throws on malformed messages', async () => {
+    const peer = createRpcPeer<Record<string, never>, Record<string, never>, BridgeEvents>({
+      localMethods: {},
+      transport: createMockTransport(),
+    });
+
+    await expect(peer.handleMessage('{"type":"invoke"}')).rejects.toThrow(
+      'Invalid bridge message: id must be a number',
+    );
+  });
+});

--- a/packages/bridge/src/client.ts
+++ b/packages/bridge/src/client.ts
@@ -1,6 +1,11 @@
-import { createBirpc } from 'birpc';
-import { deserialize, serialize } from './serializer.js';
 import { createBinaryFrame, generateTransferId } from './binary-transfer.js';
+import { serializeBridgeMessage } from './protocol.js';
+import { createRpcPeer } from './rpc-peer.js';
+import {
+  createRpcTransport,
+  type BridgeTransport,
+} from './transport.js';
+import { createWebSocketClientTransport } from './websocket-client-transport.js';
 import type {
   BridgeClientFunctions,
   BridgeServerFunctions,
@@ -12,27 +17,17 @@ import type {
   TestSuiteResult,
 } from './shared.js';
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
-/** Handlers the app must implement for the CLI to call into. */
 export type HarnessCallbacks = {
   runTests: (path: string, options: TestExecutionOptions) => Promise<TestSuiteResult>;
 };
 
-/** The app-side handle returned by connectToHarness. */
 export type HarnessHandle = {
-  /** Call once when the app is initialised and ready to run tests. */
   reportReady: (device: DeviceDescriptor) => void;
-  /** Forward a test or bundler event to the CLI. */
   emitEvent: (event: BridgeEvents) => void;
-  /** Send a screenshot to the CLI and receive a file reference for snapshot comparison. */
   transferScreenshot: (
     data: Uint8Array,
     metadata: { width: number; height: number },
   ) => Promise<FileReference>;
-  /** Request an image snapshot comparison on the CLI. */
   matchImageSnapshot: (
     screenshot: FileReference,
     testPath: string,
@@ -42,83 +37,173 @@ export type HarnessHandle = {
   disconnect: () => void;
 };
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
+export type ConnectToHarnessOptions = {
+  transport?: BridgeTransport;
+};
 
-/**
- * Connect the app to the CLI harness bridge.
- *
- * Pass the handlers the CLI can call (runTests). Returns a HarnessHandle
- * exposing the operations the app needs to drive a test run. The binary
- * transfer protocol and RPC wiring are fully encapsulated.
- */
+export { createWebSocketClientTransport };
+
+const noop = (): void => undefined;
+
 export const connectToHarness = (
   url: string,
   callbacks: HarnessCallbacks,
+  options: ConnectToHarnessOptions = {},
 ): Promise<HarnessHandle> =>
   new Promise((resolve, reject) => {
-    const ws = new WebSocket(url);
-    ws.binaryType = 'arraybuffer';
+    const transport = options.transport ?? createWebSocketClientTransport(url);
     let settled = false;
+    let peerClosed = false;
+    let offOpen: () => void = noop;
+    let offError: () => void = noop;
+    let offClose: () => void = noop;
 
     const cleanup = () => {
-      ws.removeEventListener('open', handleOpen);
-      ws.removeEventListener('error', handleError);
-      ws.removeEventListener('close', handleClose);
+      offOpen();
+      offError();
+      offClose();
     };
 
     const fail = (message: string) => {
-      if (settled) return;
+      if (settled) {
+        return;
+      }
+
       settled = true;
       cleanup();
       reject(new Error(message));
     };
 
     const handleOpen = () => {
+      if (settled) {
+        return;
+      }
+
       settled = true;
       cleanup();
 
-      const rpc = createBirpc<BridgeServerFunctions, BridgeClientFunctions>(
-        callbacks,
-        {
-          post: (data) => ws.send(data),
-          on: (handler) => {
-            ws.addEventListener('message', (event: MessageEvent<string | ArrayBuffer>) => {
-              if (typeof event.data === 'string') handler(event.data);
-            });
-          },
-          serialize,
-          deserialize,
-        },
-      );
+      const getTransportNotOpenError = () => {
+        return new Error('Harness bridge transport is not open');
+      };
+
+      const rpc = createRpcPeer<
+        BridgeClientFunctions,
+        BridgeServerFunctions,
+        BridgeEvents
+      >({
+        localMethods: callbacks,
+        transport: createRpcTransport(transport),
+      });
+
+      let offMessage: () => void = noop;
+      let offRuntimeClose: () => void = noop;
+      let offRuntimeError: () => void = noop;
+
+      const closePeer = (reason: Error) => {
+        if (peerClosed) {
+          return;
+        }
+
+        peerClosed = true;
+        offMessage();
+        offRuntimeClose();
+        offRuntimeError();
+        rpc.close(reason);
+      };
+
+      const handleMessage = async (data: string) => {
+        const controlMessage = await rpc.handleMessage(data);
+
+        if (!controlMessage) {
+          return;
+        }
+
+        if (controlMessage.type === 'ping') {
+          transport.send(
+            serializeBridgeMessage({ type: 'pong', id: controlMessage.id }),
+          );
+        }
+      };
+
+      offMessage = transport.onMessage((message) => {
+        if (typeof message !== 'string') {
+          return;
+        }
+
+        void handleMessage(message).catch((error) => {
+          closePeer(
+            error instanceof Error
+              ? error
+              : new Error('Received invalid Harness bridge message'),
+          );
+
+          if (transport.state === 'open') {
+            transport.close(1002, 'Invalid message');
+          }
+        });
+      });
+
+      offRuntimeClose = transport.onClose((event) => {
+        closePeer(
+          new Error(
+            `Harness connection closed (code ${event.code}${
+              event.reason ? `, reason: ${event.reason}` : ''
+            })`,
+          ),
+        );
+      });
+
+      offRuntimeError = transport.onError((error) => {
+        closePeer(error);
+      });
 
       resolve({
-        reportReady: (device) => void rpc.reportReady(device),
-        emitEvent: (event) => void rpc.emitEvent(event.type, event),
+        reportReady: (device) => {
+          try {
+            if (transport.state !== 'open') {
+              throw getTransportNotOpenError();
+            }
+
+            transport.send(serializeBridgeMessage({ type: 'ready', device }));
+          } catch (error) {
+            closePeer(
+              error instanceof Error ? error : getTransportNotOpenError(),
+            );
+          }
+        },
+        emitEvent: (event) => {
+          rpc.sendEvent(event);
+        },
         transferScreenshot: async (data, metadata) => {
           const transferId = generateTransferId();
-          ws.send(createBinaryFrame(transferId, data));
-          return rpc['device.screenshot.receive'](
+          transport.send(createBinaryFrame(transferId, data));
+          return rpc.invoke(
+            'device.screenshot.receive',
             { type: 'binary', transferId, size: data.length, mimeType: 'image/png' },
             metadata,
           );
         },
         matchImageSnapshot: (screenshot, testPath, options, runner) =>
-          rpc['test.matchImageSnapshot'](screenshot, testPath, options, runner),
-        disconnect: () => ws.close(),
+          rpc.invoke(
+            'test.matchImageSnapshot',
+            screenshot,
+            testPath,
+            options,
+            runner,
+          ),
+        disconnect: () => {
+          closePeer(new Error('Harness connection closed by client'));
+          transport.close();
+        },
       });
     };
 
-    const handleError = (event: Event & { message?: string }) => {
-      const detail =
-        typeof event.message === 'string' && event.message
-          ? `: ${event.message}`
-          : '';
+    const handleError = (error: Error) => {
+      const detail = error.message ? `: ${error.message}` : '';
       fail(`Failed to connect to Harness at ${url}${detail}`);
     };
 
-    const handleClose = (event: CloseEvent) => {
+    const handleClose = (event: { code: number; reason: string }) => {
       fail(
         `Harness connection at ${url} closed before becoming ready (code ${event.code}${
           event.reason ? `, reason: ${event.reason}` : ''
@@ -126,7 +211,11 @@ export const connectToHarness = (
       );
     };
 
-    ws.addEventListener('open', handleOpen);
-    ws.addEventListener('error', handleError);
-    ws.addEventListener('close', handleClose);
+    offOpen = transport.onOpen(handleOpen);
+    offError = transport.onError(handleError);
+    offClose = transport.onClose(handleClose);
+
+    if (transport.state === 'open') {
+      handleOpen();
+    }
   });

--- a/packages/bridge/src/errors.ts
+++ b/packages/bridge/src/errors.ts
@@ -9,3 +9,35 @@ export class DeviceNotRespondingError extends HarnessError {
     this.name = 'DeviceNotRespondingError';
   }
 }
+
+export type AppBridgeDisconnectedReason =
+  | 'app-disconnected'
+  | 'app-replaced'
+  | 'heartbeat-timeout'
+  | 'socket-error'
+  | 'bridge-disposed';
+
+const appBridgeDisconnectedMessage = (
+  reason: AppBridgeDisconnectedReason,
+): string => {
+  switch (reason) {
+    case 'app-replaced':
+      return 'The app bridge was replaced by a newer app connection. This can happen when the app reloads, restarts, or reconnects while a test file is still running.';
+    case 'heartbeat-timeout':
+      return 'The app bridge stopped responding during test execution. This can happen if the app was killed, crashed, became unresponsive, or lost its WebSocket connection.';
+    case 'socket-error':
+      return 'The app bridge connection failed during test execution. This can happen if the app was killed, crashed, or the underlying WebSocket connection closed unexpectedly.';
+    case 'bridge-disposed':
+      return 'The app bridge was disposed before the test file finished running.';
+    case 'app-disconnected':
+      return 'The app bridge disconnected during test execution. This can happen if the app was killed, crashed, reloaded, or restarted while the test file was running.';
+  }
+};
+
+export class AppBridgeDisconnectedError extends HarnessError {
+  constructor(public readonly reason: AppBridgeDisconnectedReason) {
+    super(appBridgeDisconnectedMessage(reason));
+    this.name = 'AppBridgeDisconnectedError';
+    this.stack = `${this.name}: ${this.message}`;
+  }
+}

--- a/packages/bridge/src/heartbeat.ts
+++ b/packages/bridge/src/heartbeat.ts
@@ -1,0 +1,67 @@
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
+export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 20_000;
+
+export type BridgeHeartbeat = {
+  notifyPong: (id: number) => void;
+  dispose: () => void;
+};
+
+export const createHeartbeat = (options: {
+  sendPing: (id: number) => void;
+  onTimeout: () => void;
+  intervalMs?: number;
+  timeoutMs?: number;
+}): BridgeHeartbeat => {
+  const intervalMs = options.intervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_HEARTBEAT_TIMEOUT_MS;
+  let nextPingId = 1;
+  let pendingPingId: number | null = null;
+  let disposed = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const clearPendingTimeout = () => {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+  };
+
+  const intervalHandle = setInterval(() => {
+    if (disposed || pendingPingId !== null) {
+      return;
+    }
+
+    const pingId = nextPingId++;
+    pendingPingId = pingId;
+    options.sendPing(pingId);
+    timeoutHandle = setTimeout(() => {
+      if (disposed || pendingPingId !== pingId) {
+        return;
+      }
+
+      pendingPingId = null;
+      timeoutHandle = null;
+      options.onTimeout();
+    }, timeoutMs);
+  }, intervalMs);
+
+  return {
+    notifyPong: (id) => {
+      if (id !== pendingPingId) {
+        return;
+      }
+
+      pendingPingId = null;
+      clearPendingTimeout();
+    },
+    dispose: () => {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      clearInterval(intervalHandle);
+      clearPendingTimeout();
+    },
+  };
+};

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,2 +1,3 @@
 export * from './shared.js';
 export * from './binary-transfer.js';
+export * from './transport.js';

--- a/packages/bridge/src/protocol.ts
+++ b/packages/bridge/src/protocol.ts
@@ -1,0 +1,233 @@
+import type { BridgeEvents, DeviceDescriptor } from './shared.js';
+
+export type SerializedBridgeError = {
+  name: string;
+  message: string;
+  stack?: string;
+  cause?: unknown;
+};
+
+export type BridgeInvokeMessage = {
+  type: 'invoke';
+  id: number;
+  method: string;
+  args: unknown[];
+};
+
+export type BridgeReturnMessage =
+  | {
+      type: 'return';
+      id: number;
+      ok: true;
+      value?: unknown;
+    }
+  | {
+      type: 'return';
+      id: number;
+      ok: false;
+      error: SerializedBridgeError;
+    };
+
+export type BridgeEventMessage<Event extends { type: string } = BridgeEvents> = {
+  type: 'event';
+  event: Event;
+};
+
+export type BridgeReadyMessage = {
+  type: 'ready';
+  device: DeviceDescriptor;
+};
+
+export type BridgePingMessage = {
+  type: 'ping';
+  id: number;
+};
+
+export type BridgePongMessage = {
+  type: 'pong';
+  id: number;
+};
+
+export type BridgeControlMessage =
+  | BridgeReadyMessage
+  | BridgePingMessage
+  | BridgePongMessage;
+
+export type BridgeMessage<Event extends { type: string } = BridgeEvents> =
+  | BridgeInvokeMessage
+  | BridgeReturnMessage
+  | BridgeEventMessage<Event>
+  | BridgeControlMessage;
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const readNumber = (value: unknown, fieldName: string): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Invalid bridge message: ${fieldName} must be a number`);
+  }
+
+  return value;
+};
+
+const readString = (value: unknown, fieldName: string): string => {
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid bridge message: ${fieldName} must be a string`);
+  }
+
+  return value;
+};
+
+const readSerializedBridgeError = (value: unknown): SerializedBridgeError => {
+  if (!isRecord(value)) {
+    throw new Error('Invalid bridge message: error must be an object');
+  }
+
+  const name = readString(value.name, 'error.name');
+  const message = readString(value.message, 'error.message');
+
+  if (value.stack !== undefined) {
+    readString(value.stack, 'error.stack');
+  }
+
+  const stack = value.stack as string | undefined;
+
+  return {
+    name,
+    message,
+    stack,
+    cause: value.cause,
+  };
+};
+
+const readDeviceDescriptor = (value: unknown): DeviceDescriptor => {
+  if (!isRecord(value)) {
+    throw new Error('Invalid bridge message: device must be an object');
+  }
+
+  return {
+    platform: readString(value.platform, 'device.platform') as DeviceDescriptor['platform'],
+    manufacturer: readString(value.manufacturer, 'device.manufacturer'),
+    model: readString(value.model, 'device.model'),
+    osVersion: readString(value.osVersion, 'device.osVersion'),
+  };
+};
+
+const readBridgeEvent = (value: unknown): BridgeEvents => {
+  if (!isRecord(value)) {
+    throw new Error('Invalid bridge message: event must be an object');
+  }
+
+  readString(value.type, 'event.type');
+
+  return value as BridgeEvents;
+};
+
+export const serializeBridgeMessage = (
+  message: BridgeMessage,
+): string => {
+  return JSON.stringify(message);
+};
+
+export const parseBridgeMessage = (raw: string): BridgeMessage => {
+  const parsed: unknown = JSON.parse(raw);
+
+  if (!isRecord(parsed)) {
+    throw new Error('Invalid bridge message: expected an object');
+  }
+
+  const messageType = readString(parsed.type, 'type');
+
+  switch (messageType) {
+    case 'invoke': {
+      readNumber(parsed.id, 'id');
+      readString(parsed.method, 'method');
+
+      if (!Array.isArray(parsed.args)) {
+        throw new Error('Invalid bridge message: args must be an array');
+      }
+
+      return parsed as BridgeInvokeMessage;
+    }
+    case 'return': {
+      readNumber(parsed.id, 'id');
+
+      if (typeof parsed.ok !== 'boolean') {
+        throw new Error('Invalid bridge message: ok must be a boolean');
+      }
+
+      if (!parsed.ok) {
+        readSerializedBridgeError(parsed.error);
+      }
+
+      return parsed as BridgeReturnMessage;
+    }
+    case 'event': {
+      readBridgeEvent(parsed.event);
+      return parsed as BridgeEventMessage;
+    }
+    case 'ready': {
+      readDeviceDescriptor(parsed.device);
+      return parsed as BridgeReadyMessage;
+    }
+    case 'ping':
+    case 'pong': {
+      readNumber(parsed.id, 'id');
+      return parsed as BridgePingMessage | BridgePongMessage;
+    }
+    default:
+      throw new Error(`Invalid bridge message: unknown type ${messageType}`);
+  }
+};
+
+export const serializeBridgeError = (
+  error: unknown,
+): SerializedBridgeError => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+      cause: error.cause,
+    };
+  }
+
+  if (isRecord(error)) {
+    const message =
+      typeof error.message === 'string'
+        ? error.message
+        : `Non-Error thrown value: ${String(error)}`;
+
+    return {
+      name: typeof error.name === 'string' ? error.name : 'NonErrorThrown',
+      message,
+      stack: typeof error.stack === 'string' ? error.stack : undefined,
+      cause: 'cause' in error ? error.cause : undefined,
+    };
+  }
+
+  return {
+    name: 'NonErrorThrown',
+    message:
+      typeof error === 'string'
+        ? error
+        : `Non-Error thrown value: ${String(error)}`,
+  };
+};
+
+export const deserializeBridgeError = (
+  serialized: SerializedBridgeError,
+): Error => {
+  const error = new Error(serialized.message, {
+    cause: serialized.cause,
+  });
+
+  error.name = serialized.name;
+
+  if (serialized.stack) {
+    error.stack = serialized.stack;
+  }
+
+  return error;
+};

--- a/packages/bridge/src/rpc-peer.ts
+++ b/packages/bridge/src/rpc-peer.ts
@@ -7,19 +7,20 @@ import {
 } from './protocol.js';
 import type { RpcTransport } from './transport.js';
 
-type RpcMethod = (...args: any[]) => unknown;
+type RpcMethod = {
+  bivarianceHack(...args: unknown[]): unknown;
+}['bivarianceHack'];
 type RpcMethods = Record<string, RpcMethod>;
 
 type PendingInvocation = {
   args: unknown[];
   method: string;
   reject: (reason: unknown) => void;
-  resolve: (value: any) => void;
+  resolve: (value: unknown) => void;
   timeout: ReturnType<typeof setTimeout> | null;
 };
 
 export type RpcPeer<
-  Local extends RpcMethods,
   Remote extends RpcMethods,
   Event extends { type: string },
 > = {
@@ -53,7 +54,7 @@ export const createRpcPeer = <
   Event extends { type: string },
 >(
   options: CreateRpcPeerOptions<Local, Event>,
-): RpcPeer<Local, Remote, Event> => {
+): RpcPeer<Remote, Event> => {
   const pendingInvocations = new Map<number, PendingInvocation>();
   let nextMessageId = 1;
   let closedReason: Error | null = null;
@@ -100,7 +101,9 @@ export const createRpcPeer = <
           args,
           method: methodName,
           reject,
-          resolve,
+          resolve: (value) => {
+            resolve(value as Awaited<ReturnType<Remote[typeof method]>>);
+          },
           timeout: null,
         };
 
@@ -132,7 +135,7 @@ export const createRpcPeer = <
 
           reject(error);
         }
-      }) as Promise<Awaited<ReturnType<Remote[typeof method]>>>;
+      });
     },
     sendEvent: (event) => {
       if (closedReason) {

--- a/packages/bridge/src/rpc-peer.ts
+++ b/packages/bridge/src/rpc-peer.ts
@@ -1,0 +1,219 @@
+import {
+  deserializeBridgeError,
+  parseBridgeMessage,
+  serializeBridgeError,
+  serializeBridgeMessage,
+  type BridgeControlMessage,
+} from './protocol.js';
+import type { RpcTransport } from './transport.js';
+
+type RpcMethod = (...args: any[]) => unknown;
+type RpcMethods = Record<string, RpcMethod>;
+
+type PendingInvocation = {
+  args: unknown[];
+  method: string;
+  reject: (reason: unknown) => void;
+  resolve: (value: any) => void;
+  timeout: ReturnType<typeof setTimeout> | null;
+};
+
+export type RpcPeer<
+  Local extends RpcMethods,
+  Remote extends RpcMethods,
+  Event extends { type: string },
+> = {
+  invoke: <K extends keyof Remote>(
+    method: K,
+    ...args: Parameters<Remote[K]>
+  ) => Promise<Awaited<ReturnType<Remote[K]>>>;
+  sendEvent: (event: Event) => void;
+  handleMessage: (raw: string) => Promise<BridgeControlMessage | null>;
+  close: (reason?: Error) => void;
+};
+
+export type CreateRpcPeerOptions<
+  Local extends RpcMethods,
+  Event extends { type: string },
+> = {
+  localMethods: Local;
+  transport: RpcTransport;
+  onEvent?: (event: Event) => void;
+  callTimeoutMs?: number;
+  createTimeoutError?: (method: string, args: unknown[]) => Error;
+};
+
+const createClosedPeerError = (): Error => {
+  return new Error('Bridge RPC peer closed');
+};
+
+export const createRpcPeer = <
+  Local extends RpcMethods,
+  Remote extends RpcMethods,
+  Event extends { type: string },
+>(
+  options: CreateRpcPeerOptions<Local, Event>,
+): RpcPeer<Local, Remote, Event> => {
+  const pendingInvocations = new Map<number, PendingInvocation>();
+  let nextMessageId = 1;
+  let closedReason: Error | null = null;
+
+  const rejectPendingInvocations = (reason: Error) => {
+    for (const [id, invocation] of pendingInvocations) {
+      if (invocation.timeout) {
+        clearTimeout(invocation.timeout);
+      }
+
+      pendingInvocations.delete(id);
+      invocation.reject(reason);
+    }
+  };
+
+  const close = (reason = createClosedPeerError()) => {
+    if (closedReason) {
+      return;
+    }
+
+    closedReason = reason;
+    rejectPendingInvocations(reason);
+  };
+
+  const sendMessage = (message: object) => {
+    if (closedReason) {
+      throw closedReason;
+    }
+
+    options.transport.send(serializeBridgeMessage(message as never));
+  };
+
+  return {
+    invoke: (method, ...args) => {
+      if (closedReason) {
+        return Promise.reject(closedReason);
+      }
+
+      const id = nextMessageId++;
+
+      return new Promise((resolve, reject) => {
+        const methodName = String(method);
+        const invocation: PendingInvocation = {
+          args,
+          method: methodName,
+          reject,
+          resolve,
+          timeout: null,
+        };
+
+        if (options.callTimeoutMs !== undefined) {
+          invocation.timeout = setTimeout(() => {
+            pendingInvocations.delete(id);
+            reject(
+              options.createTimeoutError?.(methodName, args) ??
+                new Error(`RPC call timed out: ${methodName}`),
+            );
+          }, options.callTimeoutMs);
+        }
+
+        pendingInvocations.set(id, invocation);
+
+        try {
+          sendMessage({
+            type: 'invoke',
+            id,
+            method: methodName,
+            args,
+          });
+        } catch (error) {
+          pendingInvocations.delete(id);
+
+          if (invocation.timeout) {
+            clearTimeout(invocation.timeout);
+          }
+
+          reject(error);
+        }
+      }) as Promise<Awaited<ReturnType<Remote[typeof method]>>>;
+    },
+    sendEvent: (event) => {
+      if (closedReason) {
+        return;
+      }
+
+      try {
+        sendMessage({ type: 'event', event });
+      } catch (error) {
+        close(error instanceof Error ? error : createClosedPeerError());
+      }
+    },
+    handleMessage: async (raw) => {
+      const message = parseBridgeMessage(raw);
+
+      switch (message.type) {
+        case 'invoke': {
+          const localMethod = options.localMethods[message.method];
+
+          if (!localMethod) {
+            sendMessage({
+              type: 'return',
+              id: message.id,
+              ok: false,
+              error: serializeBridgeError(
+                new Error(`Unknown bridge RPC method: ${message.method}`),
+              ),
+            });
+            return null;
+          }
+
+          try {
+            const value = await localMethod(...message.args);
+            sendMessage({
+              type: 'return',
+              id: message.id,
+              ok: true,
+              value,
+            });
+          } catch (error) {
+            sendMessage({
+              type: 'return',
+              id: message.id,
+              ok: false,
+              error: serializeBridgeError(error),
+            });
+          }
+
+          return null;
+        }
+        case 'return': {
+          const invocation = pendingInvocations.get(message.id);
+
+          if (!invocation) {
+            return null;
+          }
+
+          pendingInvocations.delete(message.id);
+
+          if (invocation.timeout) {
+            clearTimeout(invocation.timeout);
+          }
+
+          if (message.ok) {
+            invocation.resolve(message.value);
+          } else {
+            invocation.reject(deserializeBridgeError(message.error));
+          }
+
+          return null;
+        }
+        case 'event': {
+          options.onEvent?.(message.event as unknown as Event);
+          return null;
+        }
+        case 'ready':
+        case 'ping':
+        case 'pong':
+          return message;
+      }
+    },
+    close,
+  };
+};

--- a/packages/bridge/src/server.ts
+++ b/packages/bridge/src/server.ts
@@ -1,5 +1,4 @@
 import { WebSocketServer, type WebSocket } from 'ws';
-import { createBirpc, type BirpcReturn } from 'birpc';
 import { EventEmitter } from 'node:events';
 import type { Server as HttpServer } from 'node:http';
 import type { Server as HttpsServer } from 'node:https';
@@ -9,9 +8,16 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { logger } from '@react-native-harness/tools';
 import { BinaryStore, parseBinaryFrame } from './binary-transfer.js';
-import { deserialize, serialize } from './serializer.js';
 import { DeviceNotRespondingError } from './errors.js';
+import { createHeartbeat } from './heartbeat.js';
 import { matchImageSnapshot } from './image-snapshot.js';
+import { serializeBridgeMessage } from './protocol.js';
+import { createRpcPeer } from './rpc-peer.js';
+import {
+  createRpcTransport,
+  type BridgeTransport,
+} from './transport.js';
+import { createNodeWebSocketTransport } from './websocket-server-transport.js';
 import type {
   BridgeServerFunctions,
   BridgeClientFunctions,
@@ -27,26 +33,16 @@ import type {
 export { DeviceNotRespondingError } from './errors.js';
 
 const bridgeLogger = logger.child('bridge');
+const noop = (): void => undefined;
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
-/**
- * Represents a single app session — one app launch to the next restart.
- * Obtained via HarnessBridge.nextConnection().
- */
 export type AppConnection = {
   readonly device: DeviceDescriptor;
   runTests: (path: string, options: TestExecutionOptions) => Promise<TestSuiteResult>;
 };
 
 export type HarnessBridgeEvents = {
-  /** Fired when the app connects and calls reportReady. */
   connected: (connection: AppConnection) => void;
-  /** Fired when the app's WebSocket closes. */
   disconnected: () => void;
-  /** Fired for every test/bundler event the app emits. */
   event: (event: BridgeEvents) => void;
 };
 
@@ -60,30 +56,14 @@ export type HarnessBridgeOptions = TransportOptions & {
   context: HarnessContext;
 };
 
-/**
- * The persistent CLI-side bridge. Spans the full test run regardless of how
- * many times the app is restarted. Each restart produces a new AppConnection
- * via nextConnection().
- */
 export type HarnessBridge = {
-  /** The underlying WebSocket server, used to attach to Metro's HTTP server. */
   readonly ws: WebSocketServer;
-  /** The currently active app connection, null if the app is not connected. */
   readonly connection: AppConnection | null;
-  /**
-   * Resolves with the next AppConnection once the app connects and reports
-   * ready. Register this waiter before restarting the app so no ready signal
-   * is missed. Rejects if the supplied signal is aborted.
-   */
   nextConnection: (signal?: AbortSignal) => Promise<AppConnection>;
   on: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => void;
   off: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => void;
   dispose: () => void;
 };
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 const createWss = (transport: TransportOptions): Promise<WebSocketServer> => {
   if ('port' in transport) {
@@ -94,6 +74,7 @@ const createWss = (transport: TransportOptions): Promise<WebSocketServer> => {
       );
     });
   }
+
   return Promise.resolve<WebSocketServer>(
     new WebSocketServer(
       'server' in transport
@@ -113,123 +94,190 @@ const receiveScreenshot = async (
       `Binary data for transfer ${reference.transferId} not found or expired`,
     );
   }
+
   binaryStore.delete(reference.transferId);
   const file = path.join(os.tmpdir(), `harness-screenshot-${randomUUID()}.png`);
   await fs.writeFile(file, data);
   return { path: file };
 };
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
 export const createHarnessBridge = async (
   options: HarnessBridgeOptions,
 ): Promise<HarnessBridge> => {
-  const { timeout, context, ...transport } = options;
-  const wss = await createWss(transport);
+  const { timeout, context, ...transportOptions } = options;
+  const wss = await createWss(transportOptions);
   bridgeLogger.debug('bridge server ready');
 
   const emitter = new EventEmitter();
   let currentConnection: AppConnection | null = null;
+  let activeSession: { disconnect: (reason?: Error) => void; transport: BridgeTransport } | null =
+    null;
   const connectionWaiters: Array<{
     resolve: (c: AppConnection) => void;
     reject: (e: unknown) => void;
   }> = [];
 
   wss.on('connection', (ws: WebSocket) => {
+    if (activeSession) {
+      bridgeLogger.info('replacing existing app connection with a newer client');
+      activeSession.disconnect(
+        new Error('App bridge replaced by a newer connection'),
+      );
+    }
+
     bridgeLogger.debug('app connected');
+    const transport = createNodeWebSocketTransport(ws);
     const binaryStore = new BinaryStore();
     let readyConnection: AppConnection | null = null;
     let disconnected = false;
+    let offMessage: () => void = noop;
+    let offClose: () => void = noop;
+    let offError: () => void = noop;
 
-    const serverFunctions: BridgeServerFunctions = {
-      reportReady: (device) => {
-        const conn: AppConnection = {
-          device,
-          runTests: (testPath, opts) => rpc.runTests(testPath, opts),
-        };
-        readyConnection = conn;
-        currentConnection = conn;
-        bridgeLogger.debug(
-          'app ready: platform=%s model=%s',
-          device.platform,
-          device.model,
-        );
-        emitter.emit('connected', conn);
-        for (const { resolve } of connectionWaiters.splice(0)) resolve(conn);
-      },
-      emitEvent: (_, data) => {
-        emitter.emit('event', data);
-      },
-      'device.screenshot.receive': (ref) => receiveScreenshot(binaryStore, ref),
-      'test.matchImageSnapshot': (screenshot, testPath, opts) =>
-        matchImageSnapshot(screenshot, testPath, opts, context.platform.name),
+    const closeTransport = (reason?: string) => {
+      if (transport.state === 'closing' || transport.state === 'closed') {
+        return;
+      }
+
+      transport.close(1012, reason);
     };
 
-    const rpc: BirpcReturn<BridgeClientFunctions, BridgeServerFunctions> = createBirpc<BridgeClientFunctions, BridgeServerFunctions>(
-      serverFunctions,
-      {
-        post: (data) => ws.send(data),
-        on: (handler) => {
-          ws.on(
-            'message',
-            (msg: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
-              if (isBinary) {
-                try {
-                  const messageBuffer = Array.isArray(msg)
-                    ? Buffer.concat(msg)
-                    : Buffer.isBuffer(msg)
-                      ? msg
-                      : Buffer.from(msg);
-                  const { transferId, data } = parseBinaryFrame(
-                    new Uint8Array(messageBuffer),
-                  );
-                  binaryStore.add(transferId, data);
-                } catch (err) {
-                  bridgeLogger.warn('failed to parse binary frame: %s', err);
-                }
-              } else {
-                handler(msg.toString());
-              }
-            },
-          );
-        },
-        serialize,
-        deserialize,
-        timeout,
-        onFunctionError: (error, functionName, args) => {
-          bridgeLogger.error(
-            'rpc function failed: %s args=%o',
-            functionName,
-            args,
-          );
-          throw error;
-        },
-        onTimeoutError: (fn, args) => {
-          throw new DeviceNotRespondingError(fn, args);
-        },
+    const rpc = createRpcPeer<
+      BridgeServerFunctions,
+      BridgeClientFunctions,
+      BridgeEvents
+    >({
+      localMethods: {
+        'device.screenshot.receive': (ref) => receiveScreenshot(binaryStore, ref),
+        'test.matchImageSnapshot': (screenshot, testPath, opts) =>
+          matchImageSnapshot(screenshot, testPath, opts, context.platform.name),
       },
-    );
+      transport: createRpcTransport(transport),
+      onEvent: (event) => {
+        emitter.emit('event', event);
+      },
+      callTimeoutMs: timeout,
+      createTimeoutError: (functionName, args) => {
+        return new DeviceNotRespondingError(functionName, args) as unknown as Error;
+      },
+    });
+
+    const heartbeat = createHeartbeat({
+      sendPing: (id) => {
+        transport.send(serializeBridgeMessage({ type: 'ping', id }));
+      },
+      onTimeout: () => {
+        bridgeLogger.warn('app heartbeat timed out');
+        disconnect(new Error('App bridge heartbeat timed out'));
+      },
+    });
 
     const disconnect = (reason?: Error) => {
-      if (disconnected) return;
-      disconnected = true;
+      if (disconnected) {
+        return;
+      }
 
+      disconnected = true;
+      offMessage();
+      offClose();
+      offError();
       bridgeLogger.debug('app disconnected');
+      heartbeat.dispose();
       binaryStore.dispose();
+
+      if (activeSession?.transport === transport) {
+        activeSession = null;
+      }
+
       if (currentConnection === readyConnection) {
         currentConnection = null;
       }
-      rpc.$close(reason ?? new Error('App bridge disconnected'));
-      emitter.emit('disconnected');
+
+      rpc.close(reason ?? new Error('App bridge disconnected'));
+      closeTransport(reason?.message);
+
+      if (readyConnection) {
+        emitter.emit('disconnected');
+      }
     };
 
-    ws.on('close', () => {
+    activeSession = { disconnect, transport };
+
+    const handleControlMessage = async (message: string) => {
+      const controlMessage = await rpc.handleMessage(message);
+
+      if (!controlMessage) {
+        return;
+      }
+
+      switch (controlMessage.type) {
+        case 'ready': {
+          if (readyConnection) {
+            return;
+          }
+
+          const conn: AppConnection = {
+            device: controlMessage.device,
+            runTests: (testPath, opts) => rpc.invoke('runTests', testPath, opts),
+          };
+
+          readyConnection = conn;
+          currentConnection = conn;
+          bridgeLogger.debug(
+            'app ready: platform=%s model=%s',
+            controlMessage.device.platform,
+            controlMessage.device.model,
+          );
+          emitter.emit('connected', conn);
+
+          for (const { resolve } of connectionWaiters.splice(0)) {
+            resolve(conn);
+          }
+          return;
+        }
+        case 'ping': {
+          transport.send(
+            serializeBridgeMessage({ type: 'pong', id: controlMessage.id }),
+          );
+          return;
+        }
+        case 'pong': {
+          heartbeat.notifyPong(controlMessage.id);
+          return;
+        }
+      }
+    };
+
+    const handleBinaryMessage = (message: Uint8Array) => {
+      try {
+        const { transferId, data } = parseBinaryFrame(message);
+        binaryStore.add(transferId, data);
+      } catch (error) {
+        bridgeLogger.warn('failed to parse binary frame: %s', error);
+      }
+    };
+
+    offMessage = transport.onMessage((message) => {
+      if (typeof message !== 'string') {
+        handleBinaryMessage(message);
+        return;
+      }
+
+      void handleControlMessage(message).catch((error) => {
+        bridgeLogger.warn('failed to handle bridge message: %s', error);
+        disconnect(
+          error instanceof Error
+            ? error
+            : new Error('Received invalid app bridge message'),
+        );
+      });
+    });
+
+    offClose = transport.onClose(() => {
       disconnect();
     });
 
-    ws.on('error', (error) => {
+    offError = transport.onError((error) => {
       disconnect(error instanceof Error ? error : new Error('App bridge socket error'));
     });
   });
@@ -247,12 +295,11 @@ export const createHarnessBridge = async (
           signal.reason ?? new DOMException('Aborted', 'AbortError'),
         );
       }
-      // If the app already connected before this call (e.g. fast simulator
-      // startup between startAttempt and waitForReady), return it immediately
-      // rather than waiting for a second reportReady that will never come.
+
       if (currentConnection) {
         return Promise.resolve(currentConnection);
       }
+
       return new Promise((resolve, reject) => {
         const entry = { resolve, reject };
         connectionWaiters.push(entry);
@@ -260,7 +307,10 @@ export const createHarnessBridge = async (
           'abort',
           () => {
             const idx = connectionWaiters.indexOf(entry);
-            if (idx !== -1) connectionWaiters.splice(idx, 1);
+            if (idx !== -1) {
+              connectionWaiters.splice(idx, 1);
+            }
+
             reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
           },
           { once: true },
@@ -271,10 +321,17 @@ export const createHarnessBridge = async (
     off: (event, listener) => emitter.off(event, listener),
     dispose: () => {
       bridgeLogger.debug('disposing bridge');
+
       for (const { reject } of connectionWaiters.splice(0)) {
         reject(new Error('Bridge disposed'));
       }
-      for (const client of wss.clients) client.terminate();
+
+      activeSession?.disconnect(new Error('Bridge disposed'));
+
+      for (const client of wss.clients) {
+        client.terminate();
+      }
+
       wss.close();
       emitter.removeAllListeners();
     },

--- a/packages/bridge/src/server.ts
+++ b/packages/bridge/src/server.ts
@@ -8,7 +8,10 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { logger } from '@react-native-harness/tools';
 import { BinaryStore, parseBinaryFrame } from './binary-transfer.js';
-import { DeviceNotRespondingError } from './errors.js';
+import {
+  AppBridgeDisconnectedError,
+  DeviceNotRespondingError,
+} from './errors.js';
 import { createHeartbeat } from './heartbeat.js';
 import { matchImageSnapshot } from './image-snapshot.js';
 import { serializeBridgeMessage } from './protocol.js';
@@ -30,7 +33,10 @@ import type {
   TestSuiteResult,
 } from './shared.js';
 
-export { DeviceNotRespondingError } from './errors.js';
+export {
+  AppBridgeDisconnectedError,
+  DeviceNotRespondingError,
+} from './errors.js';
 
 const bridgeLogger = logger.child('bridge');
 const noop = (): void => undefined;
@@ -120,9 +126,7 @@ export const createHarnessBridge = async (
   wss.on('connection', (ws: WebSocket) => {
     if (activeSession) {
       bridgeLogger.info('replacing existing app connection with a newer client');
-      activeSession.disconnect(
-        new Error('App bridge replaced by a newer connection'),
-      );
+      activeSession.disconnect(new AppBridgeDisconnectedError('app-replaced'));
     }
 
     bridgeLogger.debug('app connected');
@@ -134,12 +138,12 @@ export const createHarnessBridge = async (
     let offClose: () => void = noop;
     let offError: () => void = noop;
 
-    const closeTransport = (reason?: string) => {
+    const closeTransport = () => {
       if (transport.state === 'closing' || transport.state === 'closed') {
         return;
       }
 
-      transport.close(1012, reason);
+      transport.close(1012);
     };
 
     const rpc = createRpcPeer<
@@ -168,7 +172,7 @@ export const createHarnessBridge = async (
       },
       onTimeout: () => {
         bridgeLogger.warn('app heartbeat timed out');
-        disconnect(new Error('App bridge heartbeat timed out'));
+        disconnect(new AppBridgeDisconnectedError('heartbeat-timeout'));
       },
     });
 
@@ -193,8 +197,8 @@ export const createHarnessBridge = async (
         currentConnection = null;
       }
 
-      rpc.close(reason ?? new Error('App bridge disconnected'));
-      closeTransport(reason?.message);
+      rpc.close(reason ?? new AppBridgeDisconnectedError('app-disconnected'));
+      closeTransport();
 
       if (readyConnection) {
         emitter.emit('disconnected');
@@ -278,7 +282,11 @@ export const createHarnessBridge = async (
     });
 
     offError = transport.onError((error) => {
-      disconnect(error instanceof Error ? error : new Error('App bridge socket error'));
+      disconnect(
+        error instanceof Error
+          ? error
+          : new AppBridgeDisconnectedError('socket-error'),
+      );
     });
   });
 
@@ -323,10 +331,10 @@ export const createHarnessBridge = async (
       bridgeLogger.debug('disposing bridge');
 
       for (const { reject } of connectionWaiters.splice(0)) {
-        reject(new Error('Bridge disposed'));
+        reject(new AppBridgeDisconnectedError('bridge-disposed'));
       }
 
-      activeSession?.disconnect(new Error('Bridge disposed'));
+      activeSession?.disconnect(new AppBridgeDisconnectedError('bridge-disposed'));
 
       for (const client of wss.clients) {
         client.terminate();

--- a/packages/bridge/src/shared.ts
+++ b/packages/bridge/src/shared.ts
@@ -154,8 +154,6 @@ export type BinaryDataReference = {
 export type ScreenshotData = BinaryDataReference;
 
 export type BridgeServerFunctions = {
-  reportReady: (device: DeviceDescriptor) => void;
-  emitEvent: (event: BridgeEvents['type'], data: BridgeEvents) => void;
   'device.screenshot.receive': (
     reference: BinaryDataReference,
     metadata: { width: number; height: number }

--- a/packages/bridge/src/transport.ts
+++ b/packages/bridge/src/transport.ts
@@ -1,0 +1,47 @@
+export type BridgeTransportState = 'connecting' | 'open' | 'closing' | 'closed';
+
+export type BridgeTransportMessage = string | Uint8Array;
+
+export type BridgeTransportCloseEvent = {
+  code: number;
+  reason: string;
+};
+
+export type BridgeTransport = {
+  readonly state: BridgeTransportState;
+  send: (message: BridgeTransportMessage) => void;
+  close: (code?: number, reason?: string) => void;
+  onOpen: (listener: () => void) => () => void;
+  onMessage: (listener: (message: BridgeTransportMessage) => void) => () => void;
+  onClose: (listener: (event: BridgeTransportCloseEvent) => void) => () => void;
+  onError: (listener: (error: Error) => void) => () => void;
+};
+
+export type RpcTransport = {
+  readonly state: BridgeTransportState;
+  send: (message: string) => void;
+};
+
+export const toTransportState = (readyState: number): BridgeTransportState => {
+  switch (readyState) {
+    case 0:
+      return 'connecting';
+    case 1:
+      return 'open';
+    case 2:
+      return 'closing';
+    default:
+      return 'closed';
+  }
+};
+
+export const createRpcTransport = (transport: BridgeTransport): RpcTransport => {
+  return {
+    get state() {
+      return transport.state;
+    },
+    send: (message) => {
+      transport.send(message);
+    },
+  };
+};

--- a/packages/bridge/src/websocket-client-transport.ts
+++ b/packages/bridge/src/websocket-client-transport.ts
@@ -1,0 +1,85 @@
+import {
+  toTransportState,
+  type BridgeTransport,
+} from './transport.js';
+
+type BrowserWebSocketLike = {
+  readonly readyState: number;
+  binaryType: BinaryType;
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+  close: (code?: number, reason?: string) => void;
+  addEventListener: {
+    (type: 'open', listener: () => void): void;
+    (
+      type: 'message',
+      listener: (event: MessageEvent<string | ArrayBuffer>) => void,
+    ): void;
+    (type: 'close', listener: (event: CloseEvent) => void): void;
+    (
+      type: 'error',
+      listener: (event: Event & { message?: string }) => void,
+    ): void;
+  };
+  removeEventListener: {
+    (type: 'open', listener: () => void): void;
+    (
+      type: 'message',
+      listener: (event: MessageEvent<string | ArrayBuffer>) => void,
+    ): void;
+    (type: 'close', listener: (event: CloseEvent) => void): void;
+    (
+      type: 'error',
+      listener: (event: Event & { message?: string }) => void,
+    ): void;
+  };
+};
+
+export const createWebSocketClientTransport = (url: string): BridgeTransport => {
+  const socket = new WebSocket(url) as BrowserWebSocketLike;
+  socket.binaryType = 'arraybuffer';
+
+  return {
+    get state() {
+      return toTransportState(socket.readyState);
+    },
+    send: (message) => {
+      socket.send(message);
+    },
+    close: (code, reason) => {
+      socket.close(code, reason);
+    },
+    onOpen: (listener) => {
+      socket.addEventListener('open', listener);
+      return () => socket.removeEventListener('open', listener);
+    },
+    onMessage: (listener) => {
+      const handleMessage = (event: MessageEvent<string | ArrayBuffer>) => {
+        if (typeof event.data === 'string') {
+          listener(event.data);
+          return;
+        }
+
+        listener(new Uint8Array(event.data));
+      };
+
+      socket.addEventListener('message', handleMessage);
+      return () => socket.removeEventListener('message', handleMessage);
+    },
+    onClose: (listener) => {
+      const handleClose = (event: CloseEvent) => {
+        listener({ code: event.code, reason: event.reason });
+      };
+
+      socket.addEventListener('close', handleClose);
+      return () => socket.removeEventListener('close', handleClose);
+    },
+    onError: (listener) => {
+      const handleError = (event: Event & { message?: string }) => {
+        listener(new Error(event.message || 'Harness connection error'));
+      };
+
+      socket.addEventListener('error', handleError);
+      return () => socket.removeEventListener('error', handleError);
+    },
+  };
+};

--- a/packages/bridge/src/websocket-server-transport.ts
+++ b/packages/bridge/src/websocket-server-transport.ts
@@ -1,0 +1,54 @@
+import type { RawData, WebSocket as NodeWebSocket } from 'ws';
+import {
+  toTransportState,
+  type BridgeTransport,
+} from './transport.js';
+
+const toUint8Array = (message: RawData): Uint8Array => {
+  const buffer = Array.isArray(message)
+    ? Buffer.concat(message)
+    : Buffer.isBuffer(message)
+      ? message
+      : Buffer.from(message);
+
+  return new Uint8Array(buffer);
+};
+
+export const createNodeWebSocketTransport = (
+  socket: NodeWebSocket,
+): BridgeTransport => {
+  return {
+    get state() {
+      return toTransportState(socket.readyState);
+    },
+    send: (message) => {
+      socket.send(message);
+    },
+    close: (code, reason) => {
+      socket.close(code, reason);
+    },
+    onOpen: () => {
+      return () => undefined;
+    },
+    onMessage: (listener) => {
+      const handleMessage = (message: RawData, isBinary: boolean) => {
+        listener(isBinary ? toUint8Array(message) : message.toString());
+      };
+
+      socket.on('message', handleMessage);
+      return () => socket.off('message', handleMessage);
+    },
+    onClose: (listener) => {
+      const handleClose = (code: number, reason: Buffer) => {
+        listener({ code, reason: reason.toString() });
+      };
+
+      socket.on('close', handleClose);
+      return () => socket.off('close', handleClose);
+    },
+    onError: (listener) => {
+      socket.on('error', listener);
+      return () => socket.off('error', listener);
+    },
+  };
+};

--- a/packages/bridge/vite.config.ts
+++ b/packages/bridge/vite.config.ts
@@ -1,0 +1,18 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/bridge',
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/packages/jest/src/__tests__/bridge.test.ts
+++ b/packages/jest/src/__tests__/bridge.test.ts
@@ -165,7 +165,7 @@ describe('bridge: createHarnessBridge + connectToHarness', () => {
         runner: '/runner.js',
       });
       const pendingRunAssertion = expect(pendingRun).rejects.toThrow(
-        'App bridge replaced by a newer connection',
+        'The app bridge was replaced by a newer app connection.',
       );
 
       const secondHandle = await connect();
@@ -211,7 +211,9 @@ describe('bridge: createHarnessBridge + connectToHarness', () => {
       const pending = bridge.nextConnection();
       bridge.dispose();
 
-      await expect(pending).rejects.toThrow('Bridge disposed');
+      await expect(pending).rejects.toThrow(
+        'The app bridge was disposed before the test file finished running.',
+      );
     });
   });
 });

--- a/packages/jest/src/__tests__/bridge.test.ts
+++ b/packages/jest/src/__tests__/bridge.test.ts
@@ -1,13 +1,14 @@
 /**
  * Integration test pairing createHarnessBridge (CLI side) with
  * connectToHarness (app side). Tests the full connection lifecycle and
- * RPC round-trip without knowing birpc internals.
+ * RPC round-trip without coupling tests to the transport internals.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HarnessBridge } from '@react-native-harness/bridge/server';
 import { createHarnessBridge } from '@react-native-harness/bridge/server';
 import { connectToHarness } from '@react-native-harness/bridge/client';
 import type { HarnessContext } from '@react-native-harness/bridge';
+import type { TestSuiteResult } from '@react-native-harness/bridge';
 
 const makeContext = (): HarnessContext => ({
   platform: {
@@ -150,6 +151,38 @@ describe('bridge: createHarnessBridge + connectToHarness', () => {
       expect(runTestsCb).toHaveBeenCalledWith('example.ts', expect.objectContaining({ runner: '/runner.js' }));
       expect(result.tests[0].name).toBe('passes');
       handle.disconnect();
+    });
+
+    it('rejects pending app calls when a newer client replaces the session', async () => {
+      const firstHandle = await connect({
+        runTests: async (): Promise<TestSuiteResult> =>
+          await new Promise<TestSuiteResult>(() => undefined),
+      });
+      firstHandle.reportReady(device);
+
+      const firstConnection = await bridge.nextConnection();
+      const pendingRun = firstConnection.runTests('example.ts', {
+        runner: '/runner.js',
+      });
+      const pendingRunAssertion = expect(pendingRun).rejects.toThrow(
+        'App bridge replaced by a newer connection',
+      );
+
+      const secondHandle = await connect();
+      secondHandle.reportReady({
+        ...device,
+        model: 'iPhone 17 Pro Replacement',
+      });
+
+      await pendingRunAssertion;
+
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(bridge.connection?.device.model).toBe(
+        'iPhone 17 Pro Replacement',
+      );
+      secondHandle.disconnect();
+      firstHandle.disconnect();
     });
   });
 

--- a/packages/jest/src/__tests__/errors.test.ts
+++ b/packages/jest/src/__tests__/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { AppBridgeDisconnectedError } from '@react-native-harness/bridge/server';
 import { NativeCrashError, PlatformReadyTimeoutError } from '../errors.js';
 
 describe('PlatformReadyTimeoutError', () => {
@@ -77,6 +78,23 @@ describe('NativeCrashError', () => {
 
     expect(error.stack).toBe(
       'NativeCrashError: The native app crashed while preparing to run this test file.'
+    );
+  });
+});
+
+describe('AppBridgeDisconnectedError', () => {
+  it('explains likely causes without exposing an internal stack', () => {
+    const error = new AppBridgeDisconnectedError('app-disconnected');
+
+    expect(error.message).toBe(
+      'The app bridge disconnected during test execution. This can happen if the app was killed, crashed, reloaded, or restarted while the test file was running.'
+    );
+    expect(error.stack).toBe(`AppBridgeDisconnectedError: ${error.message}`);
+  });
+
+  it('uses a reconnection-specific message when a newer app connection replaces the old one', () => {
+    expect(new AppBridgeDisconnectedError('app-replaced').message).toBe(
+      'The app bridge was replaced by a newer app connection. This can happen when the app reloads, restarts, or reconnects while a test file is still running.'
     );
   });
 });

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -3,7 +3,10 @@ import type { Config, Test, TestWatcher } from 'jest-runner';
 import type { TestResult as JestTestResult } from '@jest/test-result';
 import type { TestSuiteResult } from '@react-native-harness/bridge';
 import { NativeCrashError, StartupStallError } from '../errors.js';
-import { DeviceNotRespondingError } from '@react-native-harness/bridge/server';
+import {
+  AppBridgeDisconnectedError,
+  DeviceNotRespondingError,
+} from '@react-native-harness/bridge/server';
 import type { HarnessSession } from '../harness-session.js';
 import { executeRun } from '../execute-run.js';
 
@@ -244,6 +247,25 @@ describe('executeRun', () => {
       expect(onFailure).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ stack: '' }),
+      );
+    });
+
+    it('passes AppBridgeDisconnectedError to onFailure with an empty stack', async () => {
+      const onFailure = vi.fn();
+      const session = makeSession({
+        ensureAppReady: vi.fn().mockRejectedValue(
+          new AppBridgeDisconnectedError('app-disconnected'),
+        ),
+      });
+
+      await executeRun(session, [makeTest()], makeWatcher(), vi.fn(), vi.fn(), onFailure, makeGlobalConfig());
+
+      expect(onFailure).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          message: expect.stringContaining('The app bridge disconnected during test execution.'),
+          stack: '',
+        }),
       );
     });
 

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -14,7 +14,10 @@ import {
   NativeCrashError,
   StartupStallError,
 } from './errors.js';
-import { DeviceNotRespondingError } from '@react-native-harness/bridge/server';
+import {
+  AppBridgeDisconnectedError,
+  DeviceNotRespondingError,
+} from '@react-native-harness/bridge/server';
 
 const createRunSummary = () => ({ passed: 0, failed: 0, skipped: 0, todo: 0 });
 
@@ -39,6 +42,7 @@ const buildTestFailure = (err: unknown): { message: string; stack: string } => {
   if (
     err instanceof NativeCrashError ||
     err instanceof StartupStallError ||
+    err instanceof AppBridgeDisconnectedError ||
     err instanceof DeviceNotRespondingError
   ) {
     return { message: (err as Error).message, stack: '' };
@@ -164,6 +168,7 @@ export const executeRun = async (
         const isRuntimeFailure =
           err instanceof NativeCrashError ||
           err instanceof StartupStallError ||
+          err instanceof AppBridgeDisconnectedError ||
           err instanceof DeviceNotRespondingError;
 
         if (isRuntimeFailure) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,9 +226,6 @@ importers:
       '@react-native-harness/tools':
         specifier: workspace:*
         version: link:../tools
-      birpc:
-        specifier: ^2.4.0
-        version: 2.4.0
       pixelmatch:
         specifier: ^7.1.0
         version: 7.1.0
@@ -254,6 +251,12 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      vite:
+        specifier: ^7.2.2
+        version: 7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(terser@5.42.0)(yaml@2.8.0)
 
   packages/bundler-metro:
     dependencies:
@@ -3789,9 +3792,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  birpc@2.4.0:
-    resolution: {integrity: sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -12069,6 +12069,14 @@ snapshots:
     optionalDependencies:
       vite: 7.2.2(@types/node@20.19.25)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0)
 
+  '@vitest/mocker@3.2.4(vite@7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -12104,7 +12112,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.42.0)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(terser@5.42.0)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -12609,8 +12617,6 @@ snapshots:
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
-
-  birpc@2.4.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -18285,6 +18291,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite@7.2.2(@types/node@20.19.25)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
@@ -18339,6 +18366,50 @@ snapshots:
       tinyrainbow: 2.0.0
       vite: 7.2.2(@types/node@20.19.25)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@20.19.25)(jiti@2.4.2)(terser@5.42.0)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 20.19.25
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      jsdom: 22.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@22.1.0)(terser@5.42.0)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.1
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
## Description

This PR rewrites the Harness bridge to remove `birpc` and replace it with an internal, typed RPC layer built on top of an explicit bridge protocol. The new bridge separates transport concerns from RPC concerns, validates incoming control messages, and keeps binary screenshot transfer support without relying on a third-party RPC implementation.

This change is needed for Harness users because bridge failures currently tend to show up as stuck runs, ambiguous timeouts, or hard-to-diagnose disconnects when the app reloads, reconnects, crashes, or drops its socket during a test run. The new bridge makes those failure modes deterministic and easier to understand.

## Related Issue

None.

## Context

Key changes in this rewrite:

- remove the `birpc` dependency from `@react-native-harness/bridge`
- add an internal protocol for `invoke`, `return`, `event`, `ready`, `ping`, and `pong` messages
- introduce a typed RPC peer with explicit timeout handling and error serialization/deserialization
- add transport abstractions for browser and Node WebSocket runtimes instead of coupling bridge logic directly to WebSocket APIs
- add heartbeat-based liveness detection so dead app connections fail faster
- treat the newest app connection as authoritative and actively disconnect stale sessions
- surface disconnects as `AppBridgeDisconnectedError` so Jest reports bridge loss cleanly instead of leaving failures ambiguous
- expand bridge test coverage around protocol parsing, RPC behavior, heartbeat handling, and client disconnect behavior

## Testing

Added/updated automated coverage for:

- `packages/bridge/src/__tests__/client.test.ts`
- `packages/bridge/src/__tests__/heartbeat.test.ts`
- `packages/bridge/src/__tests__/protocol.test.ts`
- `packages/bridge/src/__tests__/rpc-peer.test.ts`
- `packages/jest/src/__tests__/bridge.test.ts`
- `packages/jest/src/__tests__/errors.test.ts`
- `packages/jest/src/__tests__/execute-run.test.ts`
