### PR TITLE
fix(coverage-ios): support universal binaries and fix podspec metadata

### DIFF
--- a/packages/coverage-ios/package.json
+++ b/packages/coverage-ios/package.json
@@ -33,5 +33,7 @@
   "devDependencies": {
     "react-native": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "author": "Callstack",
+  "homepage": "https://github.com/callstackincubator/react-native-harness"
 }

--- a/packages/platform-ios/src/coverage-collector.ts
+++ b/packages/platform-ios/src/coverage-collector.ts
@@ -98,11 +98,24 @@ export const generateLcov = async (options: {
 }): Promise<void> => {
   const { profdataPath, binaryPath, outputPath, sourceFilters } = options;
 
+  // llvm-cov needs an explicit -arch for universal/fat binaries (e.g. Xcode 26
+  // debug.dylib). The profile data was produced by the simulator's execution
+  // arch, which matches the host: arm64 on Apple Silicon, x86_64 on Intel.
+  const { stdout: archs } = await spawn('lipo', ['-archs', binaryPath]);
+  const archList = archs.trim().split(/\s+/);
+  let archFlag: string[] = [];
+  if (archList.length > 1) {
+    const { stdout: hostArch } = await spawn('uname', ['-m']);
+    const arch = hostArch.trim();
+    archFlag = ['-arch', archList.includes(arch) ? arch : archList[0]];
+  }
+
   const args = [
     'llvm-cov',
     'export',
     '-format=lcov',
     `-instr-profile=${profdataPath}`,
+    ...archFlag,
     binaryPath,
   ];
 


### PR DESCRIPTION
Fixes two issues that prevent native iOS coverage from working.

- `llvm-cov export` failed on universal (fat) binaries with `-arch specifier is invalid or missing`. We now detect multi-arch binaries via `lipo -archs` and pass `-arch` (preferring `arm64`); single-arch binaries are unaffected.
- The `HarnessCoverage` podspec failed CocoaPods validation because `coverage-ios/package.json` lacked `author` and `homepage`. Added both fields.