### PR TITLE
fix(jest): preserve passing exit code during teardown

### DIFF
--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -236,6 +236,25 @@ describe('executeRun', () => {
       expect(payload.status).toBe('passed');
     });
 
+    it('marks the final run state as completed', async () => {
+      const session = makeSession();
+
+      await executeRun(
+        session,
+        [makeTest()],
+        makeWatcher(),
+        makeEmitEvent().emitEvent,
+        makeGlobalConfig(),
+      );
+
+      expect(session.setRunState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          completed: true,
+          status: 'passed',
+        }),
+      );
+    });
+
     it('attaches buffered client logs to the Jest result', async () => {
       const clientLogs = [{ message: 'Loaded screen', origin: '', type: 'warn' }] satisfies NonNullable<JestTestResult['console']>;
       const session = makeSession({

--- a/packages/jest/src/__tests__/harness-session.test.ts
+++ b/packages/jest/src/__tests__/harness-session.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AppConnection } from '@react-native-harness/bridge/server';
 import {
+  getSignalExitCodeForRunState,
   waitForBridgeDisconnectOrTimeout,
   waitForStartupCrash,
+  type HarnessRunState,
 } from '../harness-session.js';
 import type { CrashMonitor } from '../crash-monitor.js';
 
@@ -89,5 +91,56 @@ describe('waitForStartupCrash', () => {
 
     await expect(waitPromise).rejects.toThrow('Aborted');
     expect(watch).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSignalExitCodeForRunState', () => {
+  const createRunState = (
+    overrides: Partial<HarnessRunState> = {}
+  ): HarnessRunState => ({
+    completed: true,
+    coverageEnabled: false,
+    runId: 'run-1',
+    startTime: 0,
+    status: 'passed',
+    summary: {
+      failed: 0,
+      passed: 1,
+      skipped: 0,
+      todo: 0,
+    },
+    testFiles: ['test.harness.ts'],
+    watchMode: false,
+    ...overrides,
+  });
+
+  it('preserves a successful exit after a completed passing run', () => {
+    expect(getSignalExitCodeForRunState(createRunState())).toBe(0);
+  });
+
+  it('fails when the run has not completed yet', () => {
+    expect(
+      getSignalExitCodeForRunState(createRunState({ completed: false }))
+    ).toBe(1);
+  });
+
+  it('fails when the completed run has failures', () => {
+    expect(
+      getSignalExitCodeForRunState(
+        createRunState({
+          status: 'failed',
+          summary: {
+            failed: 1,
+            passed: 0,
+            skipped: 0,
+            todo: 0,
+          },
+        })
+      )
+    ).toBe(1);
+  });
+
+  it('fails when no run state is available', () => {
+    expect(getSignalExitCodeForRunState(null)).toBe(1);
   });
 });

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -159,6 +159,7 @@ export const executeRun = async (
       testFiles,
       watchMode,
       coverageEnabled: globalConfig.collectCoverage,
+      completed: false,
       summary,
       status: summary.failed > 0 ? 'failed' : 'passed',
       ...overrides,
@@ -318,7 +319,7 @@ export const executeRun = async (
     if (!(err instanceof CancelRun)) throw err;
   } finally {
     const runState = updateRunState(
-      runError != null ? { error: runError, status: 'failed' } : {},
+      runError != null ? { completed: true, error: runError, status: 'failed' } : { completed: true },
     );
     await session.callHook('run:finished', {
       runId,

--- a/packages/jest/src/harness-session.ts
+++ b/packages/jest/src/harness-session.ts
@@ -127,6 +127,7 @@ export type HarnessRunState = {
   readonly testFiles: string[];
   readonly watchMode: boolean;
   readonly coverageEnabled: boolean;
+  readonly completed?: boolean;
   readonly summary?: HarnessRunSummary;
   readonly status?: HarnessRunStatus;
   readonly error?: unknown;
@@ -146,6 +147,21 @@ export type HarnessSession = {
   callHook: HarnessPluginManager<HarnessConfig, HarnessPlatform>['callHook'];
   setRunState: (state: HarnessRunState | null) => void;
   dispose: (reason?: 'normal' | 'abort' | 'error') => Promise<void>;
+};
+
+export const getSignalExitCodeForRunState = (
+  state: HarnessRunState | null
+): number => {
+  if (
+    state?.completed &&
+    state.status === 'passed' &&
+    !state.error &&
+    (state.summary?.failed ?? 0) === 0
+  ) {
+    return 0;
+  }
+
+  return 1;
 };
 
 // ---------------------------------------------------------------------------
@@ -715,7 +731,13 @@ export const createHarnessSession = async (
     // that all infrastructure is up.
     process.off('SIGTERM', onEarlySignal);
     process.off('SIGINT', onEarlySignal);
-    const onSignal = () => void dispose('abort').then(() => process.exit(0));
+    const onSignal = () => {
+      const exitCode = getSignalExitCodeForRunState(currentRun);
+      void dispose('abort').then(
+        () => process.exit(exitCode),
+        () => process.exit(1),
+      );
+    };
     process.once('SIGTERM', onSignal);
     process.once('SIGINT', onSignal);
 
@@ -854,10 +876,13 @@ export const createHarnessSession = async (
       setRunState: (state) => {
         currentRun = state;
       },
-      dispose: (reason = 'normal') => {
-        process.off('SIGTERM', onSignal);
-        process.off('SIGINT', onSignal);
-        return dispose(reason);
+      dispose: async (reason = 'normal') => {
+        try {
+          await dispose(reason);
+        } finally {
+          process.off('SIGTERM', onSignal);
+          process.off('SIGINT', onSignal);
+        }
       },
     };
   } catch (error) {

--- a/packages/tools/src/spawn.ts
+++ b/packages/tools/src/spawn.ts
@@ -40,6 +40,14 @@ export { Subprocess, SubprocessError };
 
 const activeChildProcesses = new Set<Subprocess>();
 let isProcessCleanupInstalled = false;
+let isTerminating = false;
+
+type CleanupSignal = 'SIGINT' | 'SIGTERM';
+
+const SIGNAL_EXIT_CODES: Record<CleanupSignal, number> = {
+  SIGINT: 130,
+  SIGTERM: 143,
+};
 
 const terminateActiveChildren = async () => {
   const children = [...activeChildProcesses];
@@ -62,16 +70,26 @@ const installProcessCleanup = () => {
 
   isProcessCleanupInstalled = true;
 
-  const terminate = async () => {
+  const terminate = async (signal: CleanupSignal) => {
+    if (isTerminating) {
+      return;
+    }
+
+    isTerminating = true;
+    const shouldExitAfterCleanup = process.listenerCount(signal) <= 1;
+
     await terminateActiveChildren();
-    process.exit(1);
+
+    if (shouldExitAfterCleanup) {
+      process.exit(process.exitCode ?? SIGNAL_EXIT_CODES[signal]);
+    }
   };
 
   process.on('SIGINT', () => {
-    void terminate();
+    void terminate('SIGINT');
   });
   process.on('SIGTERM', () => {
-    void terminate();
+    void terminate('SIGTERM');
   });
 };
 


### PR DESCRIPTION
## Summary

- Track whether a Harness run has actually completed before teardown/signal handling decides the process exit code.
- Preserve exit code 0 for a late SIGINT/SIGTERM after a completed passing run, while still failing incomplete or failed runs.
- Let the shared spawn cleanup terminate child processes without racing Harness session disposal for the parent process exit code.

## Verification

- `pnpm exec vitest run packages/jest/src/__tests__/harness-session.test.ts packages/jest/src/__tests__/execute-run.test.ts`
- `pnpm nx typecheck @react-native-harness/jest --skip-nx-cache`
- `pnpm nx lint @react-native-harness/jest --skip-nx-cache && pnpm nx lint @react-native-harness/tools --skip-nx-cache`

## Notes

- Full `pnpm nx test @react-native-harness/jest --skip-nx-cache` still fails locally in existing `src/__tests__/bridge.test.ts` cases because `WebSocket` is not defined in the test environment; the new/modified execute-run and harness-session tests pass in that run.
