### PR TITLE
fix(runtime): release each test file's Metro graph to prevent OOM

### DIFF
--- a/.nx/version-plans/fix-metro-per-file-graph-leak.md
+++ b/.nx/version-plans/fix-metro-per-file-graph-leak.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fixes an unbounded memory leak that OOM'd the Harness runner on suites with many test files. Each test file is fetched from Metro as its own bundle entry point, and Metro keeps a full dependency graph in memory per entry for delta updates — so the harness retained one graph (~tens of MB) per test file for the whole run, climbing until `JavaScript heap out of memory`. The runtime now releases each file's Metro graph once the file finishes (via the dev server's standard graph-release request), keeping memory flat regardless of how many test files a run contains.

--- a/packages/runtime/src/bundler/bundle.test.ts
+++ b/packages/runtime/src/bundler/bundle.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  Platform: { OS: 'ios' as string },
+  devServerUrl: 'http://localhost:8081/',
+}));
+
+vi.mock('react-native', () => ({
+  Platform: mocks.Platform,
+}));
+
+vi.mock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
+  default: () => ({ url: mocks.devServerUrl }),
+}));
+
+import { fetchModule, releaseModule } from './bundle.js';
+
+const EXPECTED_URL =
+  'http://localhost:8081/path/to/example.harness.bundle?modulesOnly=true&platform=ios';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('module bundling', () => {
+  it('fetches a module from its per-file bundle URL', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('module-source', { status: 200 }));
+
+    await expect(fetchModule('path/to/example.harness.tsx')).resolves.toBe(
+      'module-source',
+    );
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(EXPECTED_URL);
+    expect(init?.method ?? 'GET').toBe('GET');
+  });
+
+  it('releases the graph by DELETE-ing the exact same URL', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    await releaseModule('path/to/example.harness.tsx');
+
+    expect(fetchSpy).toHaveBeenCalledWith(EXPECTED_URL, { method: 'DELETE' });
+  });
+
+  it('never throws if releasing the graph fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+    await expect(
+      releaseModule('path/to/example.harness.tsx'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/runtime/src/bundler/bundle.test.ts
+++ b/packages/runtime/src/bundler/bundle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchModule, releaseModule } from './bundle.js';
 
 const mocks = vi.hoisted(() => ({
   Platform: { OS: 'ios' as string },
@@ -12,8 +13,6 @@ vi.mock('react-native', () => ({
 vi.mock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
   default: () => ({ url: mocks.devServerUrl }),
 }));
-
-import { fetchModule, releaseModule } from './bundle.js';
 
 const EXPECTED_URL =
   'http://localhost:8081/path/to/example.harness.bundle?modulesOnly=true&platform=ios';

--- a/packages/runtime/src/bundler/bundle.ts
+++ b/packages/runtime/src/bundler/bundle.ts
@@ -26,12 +26,11 @@ export const fetchModule = async (fileName: string): Promise<string> => {
 };
 
 /**
- * Ask Metro to drop the cached module graph for this entry. Metro keeps one
- * dependency graph in memory per distinct `.bundle` entry point (for delta
- * updates); because each test file is fetched as its own entry, those graphs
- * would otherwise accumulate — one full graph per file — for the whole run and
- * OOM the Metro/runner process. Metro releases a graph on an HTTP DELETE to the
- * same bundle URL, so we reuse the exact fetch URL to match its graph id.
+ * Ask Metro to drop this entry's dependency graph. Metro caches one graph per
+ * distinct `.bundle` entry (for delta updates), so fetching each test file as
+ * its own entry would otherwise retain one graph per file for the whole run and
+ * OOM the runner. Metro frees a graph on a DELETE to its bundle URL, so we reuse
+ * the exact fetch URL to match the graph id.
  */
 export const releaseModule = async (fileName: string): Promise<void> => {
   try {

--- a/packages/runtime/src/bundler/bundle.ts
+++ b/packages/runtime/src/bundler/bundle.ts
@@ -24,3 +24,19 @@ export const fetchModule = async (fileName: string): Promise<string> => {
 
   return text;
 };
+
+/**
+ * Ask Metro to drop the cached module graph for this entry. Metro keeps one
+ * dependency graph in memory per distinct `.bundle` entry point (for delta
+ * updates); because each test file is fetched as its own entry, those graphs
+ * would otherwise accumulate — one full graph per file — for the whole run and
+ * OOM the Metro/runner process. Metro releases a graph on an HTTP DELETE to the
+ * same bundle URL, so we reuse the exact fetch URL to match its graph id.
+ */
+export const releaseModule = async (fileName: string): Promise<void> => {
+  try {
+    await fetch(getModuleUrl(fileName), { method: 'DELETE' });
+  } catch {
+    // Best-effort: a failed release only costs memory, never correctness.
+  }
+};

--- a/packages/runtime/src/bundler/factory.ts
+++ b/packages/runtime/src/bundler/factory.ts
@@ -1,7 +1,7 @@
 import { BundlerEvents } from '@react-native-harness/bridge';
 import { getEmitter } from '../utils/emitter.js';
 import { Bundler } from './types.js';
-import { fetchModule } from './bundle.js';
+import { fetchModule, releaseModule } from './bundle.js';
 import { BundlingFailedError } from './errors.js';
 
 export const getBundler = (): Bundler => {
@@ -39,5 +39,6 @@ export const getBundler = (): Bundler => {
         throw error;
       }
     },
+    releaseModule: (filePath) => releaseModule(filePath),
   };
 };

--- a/packages/runtime/src/bundler/types.ts
+++ b/packages/runtime/src/bundler/types.ts
@@ -4,4 +4,5 @@ import { EventEmitter } from '../utils/emitter.js';
 export type Bundler = {
   events: EventEmitter<BundlerEvents>;
   getModule: (filePath: string) => Promise<string>;
+  releaseModule: (filePath: string) => Promise<void>;
 };

--- a/packages/runtime/src/client/factory.ts
+++ b/packages/runtime/src/client/factory.ts
@@ -88,8 +88,7 @@ export const getClient = async (): Promise<HarnessHandle> => {
           testTimeout: options.testTimeout,
         });
       } finally {
-        // Release this file's Metro graph so the dev server doesn't retain one
-        // dependency graph per test file for the whole run (unbounded → OOM).
+        // Free this file's Metro graph so graphs don't accumulate per file (OOM).
         await bundler?.releaseModule(path);
         collector?.dispose();
         runner?.dispose();

--- a/packages/runtime/src/client/factory.ts
+++ b/packages/runtime/src/client/factory.ts
@@ -88,6 +88,9 @@ export const getClient = async (): Promise<HarnessHandle> => {
           testTimeout: options.testTimeout,
         });
       } finally {
+        // Release this file's Metro graph so the dev server doesn't retain one
+        // dependency graph per test file for the whole run (unbounded → OOM).
+        await bundler?.releaseModule(path);
         collector?.dispose();
         runner?.dispose();
         events?.clearAllListeners();


### PR DESCRIPTION
## Description

Fixes an unbounded memory leak that OOMs the Harness node runner on suites with many test **files**. Each test file is fetched from Metro as its own bundle entry point (`packages/runtime/src/bundler/bundle.ts`), and Metro keeps a full dependency graph in memory per distinct entry (in `IncrementalBundler`'s revision cache, for delta updates), freeing it only when the server shuts down. So a run retained one graph — ~tens of MB — per test file, growing ~linearly with file count until `JavaScript heap out of memory`. It's per-file, not per-render: even empty `render(<View/>)` files leak, while many `it`s in one file don't.

**Fix:** after a test file finishes, ask Metro to drop that file's graph by sending an HTTP `DELETE` to the same bundle URL the file was fetched from. That is Metro's standard graph-release path (`Server` routes `req.method === "DELETE"` → `IncrementalBundler.endGraph`, which releases the DeltaBundler graph and both revision-cache entries) — the same mechanism React Native's own delta client uses on reload. Reusing the exact fetch URL guarantees the graph id matches. Verified identical in Metro 0.82.5 and 0.83.2, so it's version-stable and needs no Metro internals. Release is best-effort (a failed DELETE only costs memory, never correctness).

Notes:
- Disabling HMR would **not** fix this — the graph is cached in `initializeGraph` on every `.bundle` request, independent of `watch`/HMR.
- Platform-agnostic (same per-file fetch path on iOS/Android/web).

## Related Issue

Fixes #144. Repro branch: https://github.com/mfazekas/react-native-harness/tree/repro/per-file-metro-graph-leak

## Context

The retained graphs are only kept for delta/HMR updates, which the Harness per-file flow never uses (each file is a fresh full fetch), so dropping a file's graph once it has run is safe. The main entry-point bundle's graph is untouched (only the per-test-file module entry is released).

## Testing

- Added `packages/runtime/src/bundler/bundle.test.ts`: verifies `releaseModule` DELETEs the exact same URL `fetchModule` GETs (graph-id match) and never throws on failure.
- Full `packages/runtime` suite: no new failures vs. the `main` baseline.
- End-to-end: the repro branch (40 empty `render(<View/>)` files under `--max-old-space-size`) OOMs on `main` and is expected to keep RSS flat with this change. E2E verification on the iOS runner is best done in CI / on a real suite (it can't be unit-tested); happy to wire the empty-files repro into the playground e2e job as a permanent regression guard if desired.
