### PR TITLE
Add diagnostics tracing for harness runs

### DIFF
--- a/.nx/version-plans/add-diagnostics-tracing.md
+++ b/.nx/version-plans/add-diagnostics-tracing.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+Harness runs can now emit detailed diagnostics: enable them with the new `diagnostics` config option (or `RN_HARNESS_DIAGNOSTICS` env var) to get a Chrome Trace Event JSON file plus a console summary showing where time went during a run — session setup, Metro bundling, bridge/device round-trips, and per-file test execution. Load the trace directly in `chrome://tracing` or Perfetto. Diagnostics are off by default with zero overhead.

--- a/packages/cli/src/__tests__/jest-platform-ignore-pattern.test.ts
+++ b/packages/cli/src/__tests__/jest-platform-ignore-pattern.test.ts
@@ -45,6 +45,7 @@ const makeConfig = (): Config => ({
   crashDetectionInterval: 500,
   disableViewFlattening: false,
   forwardClientLogs: false,
+  diagnostics: false,
 });
 
 describe('createPlatformTestPathIgnorePattern', () => {

--- a/packages/cli/src/__tests__/platform-commands.test.ts
+++ b/packages/cli/src/__tests__/platform-commands.test.ts
@@ -56,6 +56,7 @@ describe('platform CLI command discovery', () => {
         crashDetectionInterval: 500,
         disableViewFlattening: false,
         forwardClientLogs: false,
+        diagnostics: false,
       } satisfies Config,
     }));
 
@@ -119,6 +120,7 @@ describe('platform CLI command discovery', () => {
         crashDetectionInterval: 500,
         disableViewFlattening: false,
         forwardClientLogs: false,
+        diagnostics: false,
       } satisfies Config,
     }));
 
@@ -160,6 +162,7 @@ describe('platform CLI command discovery', () => {
         crashDetectionInterval: 500,
         disableViewFlattening: false,
         forwardClientLogs: false,
+        diagnostics: false,
       } satisfies Config,
     }));
 
@@ -223,6 +226,7 @@ describe('platform CLI command discovery', () => {
         crashDetectionInterval: 500,
         disableViewFlattening: false,
         forwardClientLogs: false,
+        diagnostics: false,
       } satisfies Config,
     }));
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,10 @@
 export { getConfig } from './reader.js';
 export type { Config } from './types.js';
-export { ConfigSchema, DEFAULT_METRO_PORT } from './types.js';
+export {
+  ConfigSchema,
+  DEFAULT_METRO_PORT,
+  isDiagnosticsEnabled,
+} from './types.js';
 export {
   ConfigValidationError,
   ConfigNotFoundError,

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -138,6 +138,17 @@ export const ConfigSchema = z
           "When enabled, app console output is attached to the active test result's console output."
       ),
 
+    diagnostics: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'Enable diagnostics tracing for the harness session. Records spans for ' +
+          'session setup, Metro bundling, bridge/client events, and per-file test runs, ' +
+          'then writes a Chrome Trace Event JSON file and prints a summary after each run. ' +
+          'Can also be enabled via the RN_HARNESS_DIAGNOSTICS environment variable.'
+      ),
+
     // Deprecated property - used for migration detection
     include: z.array(z.string()).optional(),
   })
@@ -157,3 +168,20 @@ export const ConfigSchema = z
   );
 
 export type Config = z.infer<typeof ConfigSchema>;
+
+/**
+ * Resolves whether diagnostics tracing is enabled: either explicitly via the
+ * `diagnostics` config option, or via the `RN_HARNESS_DIAGNOSTICS` environment
+ * variable (any value other than unset, `''`, `'0'`, or `'false'`).
+ */
+export const isDiagnosticsEnabled = (
+  config: Pick<Config, 'diagnostics'> | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): boolean => {
+  if (config?.diagnostics === true) {
+    return true;
+  }
+
+  const envValue = env.RN_HARNESS_DIAGNOSTICS;
+  return !!envValue && envValue !== '0' && envValue !== 'false';
+};

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -11,6 +11,7 @@ import {
   AppBridgeDisconnectedError,
   DeviceNotRespondingError,
 } from '@react-native-harness/bridge/server';
+import { createDiagnostics } from '@react-native-harness/tools';
 import type { HarnessSession } from '../harness-session.js';
 import { executeRun } from '../execute-run.js';
 
@@ -112,6 +113,7 @@ const makeSession = (overrides: Partial<HarnessSession> = {}): HarnessSession =>
       config: {},
     },
   } as HarnessSession['context'],
+  diagnostics: createDiagnostics({ enabled: false }),
   ensureAppReady: vi.fn(resolveUndefined),
   runTestFile: vi.fn(async () => makeHarnessResult()),
   restartApp: vi.fn(resolveUndefined),

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -188,6 +188,49 @@ describe('executeRun', () => {
     });
   });
 
+  describe('diagnostics', () => {
+    it('records run.total and run.file spans when diagnostics is enabled', async () => {
+      const diagnostics = createDiagnostics({ enabled: true });
+      const session = makeSession({ diagnostics });
+
+      await executeRun(session, [makeTest('/a.ts')], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
+
+      const entries = diagnostics.flush();
+      const runEntry = entries.find((e) => e.label === 'run.total');
+      const fileEntry = entries.find((e) => e.label === 'run.file');
+
+      expect(runEntry).toMatchObject({ status: 'ok', attrs: { status: 'passed' } });
+      expect(runEntry?.attrs?.runId).toBeTypeOf('string');
+      expect(fileEntry).toMatchObject({ status: 'ok', attrs: { file: '../a.ts', status: 'passed' } });
+      expect(fileEntry?.attrs?.runId).toBeTypeOf('string');
+    });
+
+    it('still records run.total when a test throws', async () => {
+      const diagnostics = createDiagnostics({ enabled: true });
+      const session = makeSession({
+        diagnostics,
+        ensureAppReady: vi.fn(async () => { throw new Error('unexpected'); }),
+      });
+
+      await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
+
+      const entries = diagnostics.flush();
+      expect(entries.find((e) => e.label === 'run.total')).toBeDefined();
+      expect(entries.find((e) => e.label === 'run.file')).toMatchObject({
+        attrs: { status: 'failed' },
+      });
+    });
+
+    it('is a no-op when diagnostics is disabled', async () => {
+      const diagnostics = createDiagnostics({ enabled: false });
+      const session = makeSession({ diagnostics });
+
+      await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
+
+      expect(diagnostics.flush()).toEqual([]);
+    });
+  });
+
   describe('happy path', () => {
     it('emits file start, ensureAppReady, runTestFile, file success in order', async () => {
       const order: string[] = [];

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -30,6 +30,16 @@ vi.mock('../run.js', () => ({
   runHarnessTestFile: mockRunHarnessTestFile,
 }));
 
+// Mock the reporting module so diagnostics tests can inspect the entries that
+// would have been reported without touching the real filesystem, and so
+// asserting on them doesn't race with executeRun's own diagnostics.flush().
+const mockPrintSummary = vi.hoisted(() => vi.fn());
+const mockWriteTraceFile = vi.hoisted(() => vi.fn(async () => '/fake/trace.json'));
+vi.mock('../diagnostics/index.js', () => ({
+  printSummary: mockPrintSummary,
+  writeTraceFile: mockWriteTraceFile,
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -189,13 +199,22 @@ describe('executeRun', () => {
   });
 
   describe('diagnostics', () => {
+    beforeEach(() => {
+      mockPrintSummary.mockClear();
+      mockWriteTraceFile.mockClear();
+    });
+
     it('records run.total and run.file spans when diagnostics is enabled', async () => {
       const diagnostics = createDiagnostics({ enabled: true });
       const session = makeSession({ diagnostics });
 
       await executeRun(session, [makeTest('/a.ts')], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
-      const entries = diagnostics.flush();
+      // executeRun flushes and hands entries to the (mocked) reporter in its
+      // finally block, so we inspect what was reported rather than flushing
+      // the diagnostics instance ourselves.
+      expect(mockPrintSummary).toHaveBeenCalledTimes(1);
+      const entries = mockPrintSummary.mock.calls[0]?.[0] as Array<{ label: string; status: string; attrs?: Record<string, unknown> }>;
       const runEntry = entries.find((e) => e.label === 'run.total');
       const fileEntry = entries.find((e) => e.label === 'run.file');
 
@@ -203,6 +222,7 @@ describe('executeRun', () => {
       expect(runEntry?.attrs?.runId).toBeTypeOf('string');
       expect(fileEntry).toMatchObject({ status: 'ok', attrs: { file: '../a.ts', status: 'passed' } });
       expect(fileEntry?.attrs?.runId).toBeTypeOf('string');
+      expect(mockWriteTraceFile).toHaveBeenCalledWith(entries, expect.objectContaining({ runId: expect.any(String) }));
     });
 
     it('still records run.total when a test throws', async () => {
@@ -214,20 +234,22 @@ describe('executeRun', () => {
 
       await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
-      const entries = diagnostics.flush();
+      const entries = mockPrintSummary.mock.calls[0]?.[0] as Array<{ label: string; attrs?: Record<string, unknown> }>;
       expect(entries.find((e) => e.label === 'run.total')).toBeDefined();
       expect(entries.find((e) => e.label === 'run.file')).toMatchObject({
         attrs: { status: 'failed' },
       });
     });
 
-    it('is a no-op when diagnostics is disabled', async () => {
+    it('is a no-op and does not generate a report when diagnostics is disabled', async () => {
       const diagnostics = createDiagnostics({ enabled: false });
       const session = makeSession({ diagnostics });
 
       await executeRun(session, [makeTest()], makeWatcher(), makeEmitEvent().emitEvent, makeGlobalConfig());
 
       expect(diagnostics.flush()).toEqual([]);
+      expect(mockPrintSummary).not.toHaveBeenCalled();
+      expect(mockWriteTraceFile).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/jest/src/__tests__/index.test.ts
+++ b/packages/jest/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import type { Config, Test, TestEvents, TestRunnerOptions, TestWatcher } from 'j
 import type { TestSuiteResult } from '@react-native-harness/bridge';
 import type { HarnessSession } from '../harness-session.js';
 import type { executeRun as ExecuteRun } from '../execute-run.js';
-import { HarnessError } from '@react-native-harness/tools';
+import { createDiagnostics, HarnessError } from '@react-native-harness/tools';
 import JestHarness from '../index.js';
 
 const resolveUndefined = async () => undefined;
@@ -15,6 +15,7 @@ const resolveUndefined = async () => undefined;
 const mockSession: HarnessSession = {
   config: { metroPort: 8081 } as HarnessSession['config'],
   context: {} as HarnessSession['context'],
+  diagnostics: createDiagnostics({ enabled: false }),
   onTestRunnerEvent: vi.fn(() => () => undefined),
   ensureAppReady: vi.fn(resolveUndefined),
   runTestFile: vi.fn(async (): Promise<TestSuiteResult> => ({

--- a/packages/jest/src/__tests__/metro-port.test.ts
+++ b/packages/jest/src/__tests__/metro-port.test.ts
@@ -22,6 +22,7 @@ const createConfig = (overrides: Partial<HarnessConfig> = {}): HarnessConfig =>
     disableViewFlattening: false,
     entryPoint: 'index.js',
     forwardClientLogs: false,
+    diagnostics: false,
     maxAppRestarts: 2,
     metroPort: 8081,
     platformReadyTimeout: 300_000,

--- a/packages/jest/src/diagnostics/__tests__/derivers.test.ts
+++ b/packages/jest/src/diagnostics/__tests__/derivers.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import { createDiagnostics, getEmitter } from '@react-native-harness/tools';
+import type { ReportableEvent } from '@react-native-harness/bundler-metro';
+import type { AppConnection } from '@react-native-harness/bridge/server';
+import type { BridgeEvents } from '@react-native-harness/bridge';
+import { observeBridgeEvents, observeMetroEvents } from '../derivers.js';
+
+type HarnessBridgeEvents = {
+  connected: (connection: AppConnection) => void;
+  disconnected: () => void;
+  event: (event: BridgeEvents) => void;
+};
+
+const createFakeBridge = () => {
+  const listeners: { [K in keyof HarnessBridgeEvents]: Set<HarnessBridgeEvents[K]> } = {
+    connected: new Set(),
+    disconnected: new Set(),
+    event: new Set(),
+  };
+
+  return {
+    on: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => {
+      listeners[event].add(listener as never);
+    },
+    off: <T extends keyof HarnessBridgeEvents>(event: T, listener: HarnessBridgeEvents[T]) => {
+      listeners[event].delete(listener as never);
+    },
+    emitConnected: () =>
+      listeners.connected.forEach((l) =>
+        l({} as AppConnection)
+      ),
+    emitDisconnected: () => listeners.disconnected.forEach((l) => l()),
+    emitEvent: (event: BridgeEvents) => listeners.event.forEach((l) => l(event)),
+    listenerCounts: () => ({
+      connected: listeners.connected.size,
+      disconnected: listeners.disconnected.size,
+      event: listeners.event.size,
+    }),
+  };
+};
+
+describe('observeMetroEvents', () => {
+  it('is a no-op and does not subscribe when diagnostics is disabled', () => {
+    const events = getEmitter<ReportableEvent>();
+    const diagnostics = createDiagnostics({ enabled: false });
+
+    const dispose = observeMetroEvents(events, diagnostics);
+    events.emit({
+      type: 'bundle_build_started',
+      buildID: '1',
+      bundleDetails: {
+        bundleType: 'bundle',
+        dev: true,
+        entryFile: 'index.js',
+        minify: false,
+        platform: 'ios',
+      },
+    });
+
+    expect(diagnostics.flush()).toEqual([]);
+    dispose();
+  });
+
+  it('correlates bundle_build_started/done via buildID into a span', () => {
+    const events = getEmitter<ReportableEvent>();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeMetroEvents(events, diagnostics);
+
+    events.emit({
+      type: 'bundle_build_started',
+      buildID: 'build-1',
+      bundleDetails: {
+        bundleType: 'bundle',
+        dev: true,
+        entryFile: 'index.js',
+        minify: false,
+        platform: 'ios',
+      },
+    });
+    events.emit({ type: 'bundle_build_done', buildID: 'build-1' });
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.label).toBe('metro.bundle.build');
+    expect(entries[0]?.status).toBe('ok');
+    expect(entries[0]?.attrs).toMatchObject({
+      buildID: 'build-1',
+      platform: 'ios',
+      entryFile: 'index.js',
+    });
+  });
+
+  it('records a failed span for bundle_build_failed', () => {
+    const events = getEmitter<ReportableEvent>();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeMetroEvents(events, diagnostics);
+
+    events.emit({
+      type: 'bundle_build_started',
+      buildID: 'build-2',
+      bundleDetails: {
+        bundleType: 'bundle',
+        dev: true,
+        entryFile: 'index.js',
+        minify: false,
+        platform: 'android',
+      },
+    });
+    events.emit({ type: 'bundle_build_failed', buildID: 'build-2' });
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.status).toBe('error');
+  });
+
+  it('records a bundle_request_observed mark', () => {
+    const events = getEmitter<ReportableEvent>();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeMetroEvents(events, diagnostics);
+
+    events.emit({
+      type: 'bundle_request_observed',
+      platform: 'ios',
+      requestKind: 'app',
+      timestamp: new Date().toISOString(),
+      url: '/index.bundle',
+    });
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.label).toBe('metro.bundle.request');
+    expect(entries[0]?.kind).toBe('mark');
+    expect(entries[0]?.attrs).toEqual({ requestKind: 'app', platform: 'ios' });
+  });
+
+  it('dispose() unsubscribes the listener', () => {
+    const events = getEmitter<ReportableEvent>();
+    const diagnostics = createDiagnostics({ enabled: true });
+    const dispose = observeMetroEvents(events, diagnostics);
+
+    dispose();
+    events.emit({
+      type: 'bundle_request_observed',
+      platform: 'ios',
+      requestKind: 'app',
+      timestamp: new Date().toISOString(),
+      url: '/index.bundle',
+    });
+
+    expect(diagnostics.flush()).toEqual([]);
+  });
+});
+
+describe('observeBridgeEvents', () => {
+  it('is a no-op and does not subscribe when diagnostics is disabled', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: false });
+
+    observeBridgeEvents(bridge, diagnostics);
+    expect(bridge.listenerCounts()).toEqual({ connected: 0, disconnected: 0, event: 0 });
+  });
+
+  it('marks bridge.connected and bridge.disconnected', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeBridgeEvents(bridge, diagnostics);
+
+    bridge.emitConnected();
+    bridge.emitDisconnected();
+
+    const entries = diagnostics.flush();
+    expect(entries.map((e) => e.label)).toEqual(['bridge.connected', 'bridge.disconnected']);
+    expect(entries.every((e) => e.kind === 'mark')).toBe(true);
+  });
+
+  it('records client.bundle.module for module bundling events', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeBridgeEvents(bridge, diagnostics);
+
+    bridge.emitEvent({ type: 'module-bundling-finished', file: 'a.ts', duration: 12 });
+    bridge.emitEvent({
+      type: 'module-bundling-failed',
+      file: 'b.ts',
+      duration: 5,
+      error: 'boom',
+    });
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      label: 'client.bundle.module',
+      duration: 12,
+      status: 'ok',
+      attrs: { file: 'a.ts' },
+    });
+    expect(entries[1]).toMatchObject({
+      label: 'client.bundle.module',
+      duration: 5,
+      status: 'error',
+      attrs: { file: 'b.ts' },
+    });
+  });
+
+  it('records client.setup-file for setup file bundling events', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeBridgeEvents(bridge, diagnostics);
+
+    bridge.emitEvent({
+      type: 'setup-file-bundling-finished',
+      file: 'setup.ts',
+      setupType: 'setupFiles',
+      duration: 20,
+    });
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      label: 'client.setup-file',
+      duration: 20,
+      attrs: { file: 'setup.ts', setupType: 'setupFiles' },
+    });
+  });
+
+  it('records client.collect for collection-finished', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeBridgeEvents(bridge, diagnostics);
+
+    bridge.emitEvent({
+      type: 'collection-finished',
+      file: 'a.test.ts',
+      duration: 8,
+      totalTests: 3,
+    });
+
+    const entries = diagnostics.flush();
+    expect(entries[0]).toMatchObject({
+      label: 'client.collect',
+      duration: 8,
+      attrs: { file: 'a.test.ts', totalTests: 3 },
+    });
+  });
+
+  it('records client.suite and client.test with status', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeBridgeEvents(bridge, diagnostics);
+
+    bridge.emitEvent({
+      type: 'suite-finished',
+      file: 'a.test.ts',
+      name: 'my suite',
+      duration: 100,
+      status: 'failed',
+    });
+    bridge.emitEvent({
+      type: 'test-finished',
+      file: 'a.test.ts',
+      suite: 'my suite',
+      name: 'my test',
+      ancestorTitles: [],
+      fullName: 'my suite my test',
+      startedAt: Date.now(),
+      duration: 15,
+      status: 'passed',
+    });
+
+    const entries = diagnostics.flush();
+    expect(entries[0]).toMatchObject({ label: 'client.suite', status: 'error' });
+    expect(entries[1]).toMatchObject({ label: 'client.test', status: 'ok' });
+  });
+
+  it('anchors recorded entries near "now - duration" using the host clock', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    observeBridgeEvents(bridge, diagnostics);
+
+    const before = Date.now();
+    bridge.emitEvent({ type: 'module-bundling-finished', file: 'a.ts', duration: 50 });
+    const after = Date.now();
+
+    const [entry] = diagnostics.flush();
+    expect(entry?.startTime).toBeGreaterThanOrEqual(before - 50 - 5);
+    expect(entry?.startTime).toBeLessThanOrEqual(after - 50 + 5);
+  });
+
+  it('dispose() unsubscribes all listeners', () => {
+    const bridge = createFakeBridge();
+    const diagnostics = createDiagnostics({ enabled: true });
+    const dispose = observeBridgeEvents(bridge, diagnostics);
+
+    dispose();
+    expect(bridge.listenerCounts()).toEqual({ connected: 0, disconnected: 0, event: 0 });
+
+    bridge.emitConnected();
+    expect(diagnostics.flush()).toEqual([]);
+  });
+});

--- a/packages/jest/src/diagnostics/__tests__/report.test.ts
+++ b/packages/jest/src/diagnostics/__tests__/report.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { DiagnosticEntry } from '@react-native-harness/tools';
+import { printSummary, writeTraceFile } from '../report.js';
+
+const makeSpanEntry = (
+  overrides: Partial<DiagnosticEntry> = {},
+): DiagnosticEntry => ({
+  label: 'metro.bundle.build',
+  startTime: 1_000,
+  duration: 250,
+  status: 'ok',
+  kind: 'span',
+  ...overrides,
+});
+
+describe('writeTraceFile', () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    projectRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'react-native-harness-report-test-'),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('writes a Chrome Trace Event JSON file under .harness/diagnostics', async () => {
+    const entries = [
+      makeSpanEntry({ attrs: { file: 'a.test.ts' } }),
+      makeSpanEntry({
+        label: 'bridge.connected',
+        duration: 0,
+        kind: 'mark',
+      }),
+    ];
+
+    const filePath = await writeTraceFile(entries, {
+      projectRoot,
+      runId: 'run-123',
+    });
+
+    expect(filePath).toBe(
+      path.join(projectRoot, '.harness', 'diagnostics', 'run-123.json'),
+    );
+
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as { traceEvents: Array<Record<string, unknown>> };
+
+    expect(parsed.traceEvents).toHaveLength(2);
+    expect(parsed.traceEvents[0]).toMatchObject({
+      name: 'metro.bundle.build',
+      ph: 'X',
+      ts: 1_000 * 1000,
+      dur: 250 * 1000,
+      pid: 1,
+      tid: 1,
+      args: { file: 'a.test.ts' },
+    });
+    expect(parsed.traceEvents[1]).toMatchObject({
+      name: 'bridge.connected',
+      ph: 'i',
+      s: 'g',
+    });
+  });
+
+  it('creates the diagnostics directory recursively when missing', async () => {
+    const filePath = await writeTraceFile([makeSpanEntry()], {
+      projectRoot,
+      runId: 'run-456',
+    });
+
+    const stat = await fs.stat(filePath);
+    expect(stat.isFile()).toBe(true);
+  });
+});
+
+describe('printSummary', () => {
+  it('does nothing when there are no entries', () => {
+    const lines: string[] = [];
+    printSummary([], (line) => lines.push(line));
+    expect(lines).toEqual([]);
+  });
+
+  it('groups by top-level namespace and sorts labels by total duration desc', () => {
+    const lines: string[] = [];
+    printSummary(
+      [
+        makeSpanEntry({ label: 'metro.bundle.build', duration: 100 }),
+        makeSpanEntry({ label: 'metro.bundle.build', duration: 200 }),
+        makeSpanEntry({ label: 'metro.init', duration: 50 }),
+        makeSpanEntry({ label: 'client.test', duration: 5000 }),
+      ],
+      (line) => lines.push(line),
+    );
+
+    const metroHeaderIndex = lines.indexOf('  metro');
+    const clientHeaderIndex = lines.indexOf('  client');
+    expect(metroHeaderIndex).toBeGreaterThanOrEqual(0);
+    expect(clientHeaderIndex).toBeGreaterThanOrEqual(0);
+
+    const bundleLine = lines.find((l) => l.includes('metro.bundle.build'));
+    expect(bundleLine).toContain('count=2');
+    expect(bundleLine).toContain('total=300ms');
+    expect(bundleLine).toContain('max=200ms');
+
+    const clientLine = lines.find((l) => l.includes('client.test'));
+    expect(clientLine).toContain('total=5.0s');
+  });
+
+  it('formats sub-second durations in ms and second+ durations in s', () => {
+    const lines: string[] = [];
+    printSummary(
+      [
+        makeSpanEntry({ label: 'a.b', duration: 999 }),
+        makeSpanEntry({ label: 'a.c', duration: 1500 }),
+      ],
+      (line) => lines.push(line),
+    );
+
+    expect(lines.find((l) => l.includes('a.b'))).toContain('999ms');
+    expect(lines.find((l) => l.includes('a.c'))).toContain('1.5s');
+  });
+});

--- a/packages/jest/src/diagnostics/derivers.ts
+++ b/packages/jest/src/diagnostics/derivers.ts
@@ -1,0 +1,170 @@
+import type { Diagnostics, DiagnosticSpan } from '@react-native-harness/tools';
+import type { HarnessBridge } from '@react-native-harness/bridge/server';
+import type { BridgeEvents } from '@react-native-harness/bridge';
+import type { MetroInstance, ReportableEvent } from '@react-native-harness/bundler-metro';
+
+/**
+ * Span/mark derivers translate existing domain event streams (Metro build
+ * events, bridge/device events) into diagnostics entries. This is the only
+ * place in the jest package that maps event shapes to diagnostic labels -
+ * business logic elsewhere stays free of diagnostics calls.
+ */
+
+const noopDispose = (): void => undefined;
+
+/**
+ * Observes Metro's reporter event stream and derives:
+ * - `metro.bundle.build` spans, correlated by `buildID` across
+ *   bundle_build_started -> bundle_build_done|bundle_build_failed.
+ * - `metro.bundle.request` marks from bundle_request_observed events.
+ */
+export const observeMetroEvents = (
+  events: MetroInstance['events'],
+  diagnostics: Diagnostics
+): (() => void) => {
+  if (!diagnostics.enabled) {
+    return noopDispose;
+  }
+
+  const inflightBuilds = new Map<string, DiagnosticSpan>();
+
+  const listener = (event: ReportableEvent): void => {
+    switch (event.type) {
+      case 'bundle_build_started': {
+        const span = diagnostics.start('metro.bundle.build', {
+          buildID: event.buildID,
+          platform: event.bundleDetails.platform,
+          entryFile: event.bundleDetails.entryFile,
+          dev: event.bundleDetails.dev,
+        });
+        inflightBuilds.set(event.buildID, span);
+        return;
+      }
+      case 'bundle_build_done': {
+        const span = inflightBuilds.get(event.buildID);
+        inflightBuilds.delete(event.buildID);
+        span?.end();
+        return;
+      }
+      case 'bundle_build_failed': {
+        const span = inflightBuilds.get(event.buildID);
+        inflightBuilds.delete(event.buildID);
+        span?.fail(new Error(`Metro bundle build ${event.buildID} failed`));
+        return;
+      }
+      case 'bundle_request_observed': {
+        diagnostics.mark('metro.bundle.request', {
+          requestKind: event.requestKind,
+          platform: event.platform,
+        });
+        return;
+      }
+      default:
+        return;
+    }
+  };
+
+  events.addListener(listener);
+  return () => {
+    events.removeListener(listener);
+  };
+};
+
+type MinimalBridge = Pick<HarnessBridge, 'on' | 'off'>;
+
+/**
+ * Observes bridge connection lifecycle and device-reported bridge events and
+ * derives:
+ * - `bridge.connected` / `bridge.disconnected` marks.
+ * - `client.bundle.module`, `client.setup-file`, `client.collect`,
+ *   `client.suite`, `client.test` completed spans, recorded via
+ *   diagnostics.record() since these events arrive with a `duration` already
+ *   measured on the (unsynced) device clock; we anchor them at host receipt
+ *   time instead of trusting the device's absolute clock.
+ */
+export const observeBridgeEvents = (
+  bridge: MinimalBridge,
+  diagnostics: Diagnostics
+): (() => void) => {
+  if (!diagnostics.enabled) {
+    return noopDispose;
+  }
+
+  const onConnected = (): void => {
+    diagnostics.mark('bridge.connected');
+  };
+
+  const onDisconnected = (): void => {
+    diagnostics.mark('bridge.disconnected');
+  };
+
+  const onEvent = (event: BridgeEvents): void => {
+    switch (event.type) {
+      case 'module-bundling-finished':
+        diagnostics.record({
+          label: 'client.bundle.module',
+          duration: event.duration,
+          attrs: { file: event.file },
+        });
+        return;
+      case 'module-bundling-failed':
+        diagnostics.record({
+          label: 'client.bundle.module',
+          duration: event.duration,
+          attrs: { file: event.file },
+          status: 'error',
+        });
+        return;
+      case 'setup-file-bundling-finished':
+        diagnostics.record({
+          label: 'client.setup-file',
+          duration: event.duration,
+          attrs: { file: event.file, setupType: event.setupType },
+        });
+        return;
+      case 'setup-file-bundling-failed':
+        diagnostics.record({
+          label: 'client.setup-file',
+          duration: event.duration,
+          attrs: { file: event.file, setupType: event.setupType },
+          status: 'error',
+        });
+        return;
+      case 'collection-finished':
+        diagnostics.record({
+          label: 'client.collect',
+          duration: event.duration,
+          attrs: { file: event.file, totalTests: event.totalTests },
+        });
+        return;
+      case 'suite-finished':
+        diagnostics.record({
+          label: 'client.suite',
+          duration: event.duration,
+          attrs: { file: event.file, name: event.name, status: event.status },
+          status: event.status === 'failed' ? 'error' : 'ok',
+        });
+        return;
+      case 'test-finished':
+        diagnostics.record({
+          label: 'client.test',
+          duration: event.duration,
+          attrs: { file: event.file, name: event.name, status: event.status },
+          status: event.status === 'failed' ? 'error' : 'ok',
+        });
+        return;
+      default:
+        return;
+    }
+  };
+
+  bridge.on('connected', onConnected);
+  bridge.on('disconnected', onDisconnected);
+  bridge.on('event', onEvent);
+
+  return () => {
+    bridge.off('connected', onConnected);
+    bridge.off('disconnected', onDisconnected);
+    bridge.off('event', onEvent);
+  };
+};

--- a/packages/jest/src/diagnostics/index.ts
+++ b/packages/jest/src/diagnostics/index.ts
@@ -1,1 +1,2 @@
 export { observeMetroEvents, observeBridgeEvents } from './derivers.js';
+export { writeTraceFile, printSummary } from './report.js';

--- a/packages/jest/src/diagnostics/index.ts
+++ b/packages/jest/src/diagnostics/index.ts
@@ -1,0 +1,1 @@
+export { observeMetroEvents, observeBridgeEvents } from './derivers.js';

--- a/packages/jest/src/diagnostics/report.ts
+++ b/packages/jest/src/diagnostics/report.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { DiagnosticEntry } from '@react-native-harness/tools';
+import { getHarnessRootPath } from '@react-native-harness/tools';
+
+type TraceEvent = {
+  name: string;
+  ph: 'X' | 'i';
+  ts: number;
+  dur?: number;
+  s?: 'g';
+  pid: number;
+  tid: number;
+  args?: Record<string, unknown>;
+};
+
+const TRACE_PID = 1;
+const TRACE_TID = 1;
+
+const toTraceEvent = (entry: DiagnosticEntry): TraceEvent => {
+  if (entry.kind === 'mark') {
+    return {
+      name: entry.label,
+      ph: 'i',
+      s: 'g',
+      ts: entry.startTime * 1000,
+      pid: TRACE_PID,
+      tid: TRACE_TID,
+      args: entry.attrs,
+    };
+  }
+
+  return {
+    name: entry.label,
+    ph: 'X',
+    ts: entry.startTime * 1000,
+    dur: entry.duration * 1000,
+    pid: TRACE_PID,
+    tid: TRACE_TID,
+    args: entry.attrs,
+  };
+};
+
+export const writeTraceFile = async (
+  entries: DiagnosticEntry[],
+  options: { projectRoot: string; runId: string }
+): Promise<string> => {
+  const dir = path.join(getHarnessRootPath(options.projectRoot), 'diagnostics');
+  await fs.mkdir(dir, { recursive: true });
+
+  const filePath = path.join(dir, `${options.runId}.json`);
+  const trace = { traceEvents: entries.map(toTraceEvent) };
+
+  await fs.writeFile(filePath, JSON.stringify(trace), 'utf-8');
+
+  return filePath;
+};
+
+const formatDuration = (ms: number): string => {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  return `${Math.round(ms)}ms`;
+};
+
+const getNamespace = (label: string): string => label.split('.')[0] ?? label;
+
+type LabelStats = {
+  label: string;
+  count: number;
+  totalMs: number;
+  maxMs: number;
+};
+
+export const printSummary = (
+  entries: DiagnosticEntry[],
+  log: (line: string) => void
+): void => {
+  if (entries.length === 0) {
+    return;
+  }
+
+  const statsByLabel = new Map<string, LabelStats>();
+  for (const entry of entries) {
+    const existing = statsByLabel.get(entry.label);
+    if (existing) {
+      existing.count += 1;
+      existing.totalMs += entry.duration;
+      existing.maxMs = Math.max(existing.maxMs, entry.duration);
+    } else {
+      statsByLabel.set(entry.label, {
+        label: entry.label,
+        count: 1,
+        totalMs: entry.duration,
+        maxMs: entry.duration,
+      });
+    }
+  }
+
+  const byNamespace = new Map<string, LabelStats[]>();
+  for (const stats of statsByLabel.values()) {
+    const namespace = getNamespace(stats.label);
+    const group = byNamespace.get(namespace);
+    if (group) {
+      group.push(stats);
+    } else {
+      byNamespace.set(namespace, [stats]);
+    }
+  }
+
+  log('Diagnostics summary:');
+  const sortedNamespaces = [...byNamespace.entries()].sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (const [namespace, group] of sortedNamespaces) {
+    log(`  ${namespace}`);
+    group.sort((a, b) => b.totalMs - a.totalMs);
+    for (const stats of group) {
+      log(
+        `    ${stats.label}: count=${stats.count} total=${formatDuration(stats.totalMs)} max=${formatDuration(stats.maxMs)}`
+      );
+    }
+  }
+};

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -29,6 +29,10 @@ import {
   shouldRunHarnessTestFile,
 } from './test-file-platform-filter.js';
 import { formatHarnessErrorMessage } from './format-harness-error.js';
+import { logger } from '@react-native-harness/tools';
+import { printSummary, writeTraceFile } from './diagnostics/index.js';
+
+const diagnosticsLogger = logger.child('diagnostics');
 
 type EmitTestEvent = <Name extends keyof TestEvents>(
   eventName: Name,
@@ -346,5 +350,16 @@ export const executeRun = async (
     await caseEventChain;
     unsubscribe();
     runSpan.end({ runId, status: finalStatus });
+
+    if (session.diagnostics.enabled) {
+      const entries = session.diagnostics.flush();
+      try {
+        printSummary(entries, (line) => diagnosticsLogger.info(line));
+        const tracePath = await writeTraceFile(entries, { projectRoot: rootDir, runId });
+        diagnosticsLogger.info(`wrote diagnostics trace to ${tracePath}`);
+      } catch (reportError) {
+        diagnosticsLogger.warn('failed to write diagnostics report: %s', reportError);
+      }
+    }
   }
 };

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -136,6 +136,8 @@ export const executeRun = async (
   globalConfig: Config.GlobalConfig,
 ): Promise<void> => {
   const runId = randomUUID();
+  const diagnostics = session.diagnostics.child({ runId });
+  const runSpan = diagnostics.start('run.total', { runId });
   const startTime = Date.now();
   const watchMode = globalConfig.watch || globalConfig.watchAll;
   const rootDir = globalConfig.rootDir ?? process.cwd();
@@ -216,22 +218,82 @@ export const executeRun = async (
       };
 
       await session.callHook('test-file:started', { runId, file: relativeTestPath });
+      const fileSpan = diagnostics.start('run.file', { file: relativeTestPath });
+      let fileStatus: 'passed' | 'failed' | 'skipped' | 'todo' = 'failed';
 
-      if (
-        !shouldRunHarnessTestFile(test.path, platformId, knownPlatformIds)
-      ) {
+      try {
+        if (
+          !shouldRunHarnessTestFile(test.path, platformId, knownPlatformIds)
+        ) {
+          try {
+            await emitEvent('test-file-start', test);
+            const skippedResult = createPlatformSkippedTestResult(test.path);
+            applyJestResultToSummary(summary, skippedResult);
+            updateRunState();
+            fileStatus = 'skipped';
+            await emitTestFileFinished({
+              status: 'skipped',
+              duration: Date.now() - fileStartedAt,
+              result: null,
+            });
+            await emitEvent('test-file-success', test, skippedResult);
+          } catch (err) {
+            fileStatus = 'failed';
+            if (!emittedTestFileFinished) {
+              await emitTestFileFinished({
+                status: 'failed',
+                duration: Date.now() - fileStartedAt,
+                result: null,
+              });
+            }
+            updateRunState({ error: err });
+            await emitEvent('test-file-failure', test, buildTestFailure(err));
+          }
+          continue;
+        }
+
         try {
+          if ((shouldResetEnv && !isFirstTest) || shouldRestartAfterTimeout) {
+            await session.restartApp(test.path);
+            shouldRestartAfterTimeout = false;
+          }
+          isFirstTest = false;
+
+          session.flushClientLogs();
           await emitEvent('test-file-start', test);
-          const skippedResult = createPlatformSkippedTestResult(test.path);
-          applyJestResultToSummary(summary, skippedResult);
-          updateRunState();
-          await emitTestFileFinished({
-            status: 'skipped',
-            duration: Date.now() - fileStartedAt,
-            result: null,
+          await session.ensureAppReady(test.path);
+
+          // Crash detection is handled inside session.runTestFile; NativeCrashError
+          // propagates here if a crash wins the race.
+          const result = await runHarnessTestFile({
+            testPath: test.path,
+            session,
+            globalConfig,
+            projectConfig: test.context.config,
           });
-          await emitEvent('test-file-success', test, skippedResult);
+
+          applyJestResultToSummary(summary, result.jestResult);
+          const clientLogs = session.flushClientLogs();
+          if (clientLogs.length > 0) {
+            result.jestResult.console = clientLogs;
+          }
+          updateRunState();
+          fileStatus = result.harnessResult.status;
+          await emitTestFileFinished({
+            status: result.harnessResult.status,
+            duration: result.duration,
+            result: result.harnessResult,
+          });
+          const didRuntimeTimeout = hasRuntimeTimeout(result.harnessResult);
+          shouldRestartAfterTimeout = didRuntimeTimeout;
+          await caseEventChain;
+          await emitEvent('test-file-success', test, result.jestResult);
+          if (didRuntimeTimeout) {
+            await session.restartApp(test.path);
+            shouldRestartAfterTimeout = false;
+          }
         } catch (err) {
+          fileStatus = 'failed';
           if (!emittedTestFileFinished) {
             await emitTestFileFinished({
               status: 'failed',
@@ -239,79 +301,29 @@ export const executeRun = async (
               result: null,
             });
           }
-          updateRunState({ error: err });
+
+          const isRuntimeFailure =
+            err instanceof NativeCrashError ||
+            err instanceof RuntimeDisconnectError ||
+            err instanceof StartupStallError ||
+            err instanceof AppBridgeDisconnectedError ||
+            err instanceof DeviceNotRespondingError;
+
+          if (isRuntimeFailure) {
+            summary.failed += 1;
+            updateRunState();
+          }
+
+          if (err instanceof NativeCrashError || err instanceof RuntimeDisconnectError) {
+            session.resetCrashState();
+          }
+
+          updateRunState({ error: isRuntimeFailure ? undefined : err });
+          await caseEventChain;
           await emitEvent('test-file-failure', test, buildTestFailure(err));
         }
-        continue;
-      }
-
-      try {
-        if ((shouldResetEnv && !isFirstTest) || shouldRestartAfterTimeout) {
-          await session.restartApp(test.path);
-          shouldRestartAfterTimeout = false;
-        }
-        isFirstTest = false;
-
-        session.flushClientLogs();
-        await emitEvent('test-file-start', test);
-        await session.ensureAppReady(test.path);
-
-        // Crash detection is handled inside session.runTestFile; NativeCrashError
-        // propagates here if a crash wins the race.
-        const result = await runHarnessTestFile({
-          testPath: test.path,
-          session,
-          globalConfig,
-          projectConfig: test.context.config,
-        });
-
-        applyJestResultToSummary(summary, result.jestResult);
-        const clientLogs = session.flushClientLogs();
-        if (clientLogs.length > 0) {
-          result.jestResult.console = clientLogs;
-        }
-        updateRunState();
-        await emitTestFileFinished({
-          status: result.harnessResult.status,
-          duration: result.duration,
-          result: result.harnessResult,
-        });
-        const didRuntimeTimeout = hasRuntimeTimeout(result.harnessResult);
-        shouldRestartAfterTimeout = didRuntimeTimeout;
-        await caseEventChain;
-        await emitEvent('test-file-success', test, result.jestResult);
-        if (didRuntimeTimeout) {
-          await session.restartApp(test.path);
-          shouldRestartAfterTimeout = false;
-        }
-      } catch (err) {
-        if (!emittedTestFileFinished) {
-          await emitTestFileFinished({
-            status: 'failed',
-            duration: Date.now() - fileStartedAt,
-            result: null,
-          });
-        }
-
-        const isRuntimeFailure =
-          err instanceof NativeCrashError ||
-          err instanceof RuntimeDisconnectError ||
-          err instanceof StartupStallError ||
-          err instanceof AppBridgeDisconnectedError ||
-          err instanceof DeviceNotRespondingError;
-
-        if (isRuntimeFailure) {
-          summary.failed += 1;
-          updateRunState();
-        }
-
-        if (err instanceof NativeCrashError || err instanceof RuntimeDisconnectError) {
-          session.resetCrashState();
-        }
-
-        updateRunState({ error: isRuntimeFailure ? undefined : err });
-        await caseEventChain;
-        await emitEvent('test-file-failure', test, buildTestFailure(err));
+      } finally {
+        fileSpan.end({ status: fileStatus });
       }
     }
   } catch (err) {
@@ -321,16 +333,18 @@ export const executeRun = async (
     const runState = updateRunState(
       runError != null ? { completed: true, error: runError, status: 'failed' } : { completed: true },
     );
+    const finalStatus = runState.status ?? (runError != null ? 'failed' : 'passed');
     await session.callHook('run:finished', {
       runId,
       startTime,
       duration: Date.now() - startTime,
       testFiles,
       summary,
-      status: runState.status ?? (runError != null ? 'failed' : 'passed'),
+      status: finalStatus,
       ...(runError != null ? { error: runError } : {}),
     });
     await caseEventChain;
     unsubscribe();
+    runSpan.end({ runId, status: finalStatus });
   }
 };

--- a/packages/jest/src/harness-session.ts
+++ b/packages/jest/src/harness-session.ts
@@ -36,12 +36,15 @@ import {
 } from '@react-native-harness/plugins';
 import {
   createCrashArtifactWriter,
+  createDiagnostics,
   logger,
   getTimeoutSignal,
   raceAbortSignals,
+  type Diagnostics,
 } from '@react-native-harness/tools';
 import {
   getConfig,
+  isDiagnosticsEnabled,
   type Config as HarnessConfig,
   ConfigSchema,
 } from '@react-native-harness/config';
@@ -62,6 +65,7 @@ import {
   type ResourceLockManager,
   type ResourceLease,
 } from './resource-lock.js';
+import { observeBridgeEvents, observeMetroEvents } from './diagnostics/index.js';
 import { resolveHarnessMetroPort } from './metro-port.js';
 import { getAdditionalCliArgs } from './cli-args.js';
 import {
@@ -138,6 +142,7 @@ export type HarnessRunTestsOptions = Exclude<TestExecutionOptions, 'platform'>;
 export type HarnessSession = {
   readonly config: HarnessConfig;
   readonly context: HarnessContext;
+  readonly diagnostics: Diagnostics;
   onTestRunnerEvent: (listener: (event: TestRunnerEvents) => void) => () => void;
   runTestFile: (path: string, options: HarnessRunTestsOptions) => Promise<TestSuiteResult>;
   ensureAppReady: (testFilePath: string) => Promise<void>;
@@ -422,8 +427,17 @@ export const createHarnessSession = async (
 ): Promise<HarnessSession> => {
   preRunMessage.remove(process.stderr);
 
+  const setupStartedAt = Date.now();
   const { harnessConfig, platform, projectRoot } = await loadConfig(globalConfig);
   applyEnvVars(harnessConfig, globalConfig);
+
+  const diagnostics = createDiagnostics({
+    enabled: isDiagnosticsEnabled(harnessConfig),
+  });
+  diagnostics.record({
+    label: 'session.config.load',
+    duration: Date.now() - setupStartedAt,
+  });
 
   sessionLogger.debug(
     'creating session for runner=%s platform=%s',
@@ -445,20 +459,25 @@ export const createHarnessSession = async (
 
   logTestRunHeader(platform);
 
-  const resourceLease = await lockManager.acquire(resourceLockKey, {
-    signal: setupController.signal,
-    onWait: () => {
-      didWaitForResourceLock = true;
-      logRunnerWaitingInQueue(platform);
-      sessionLogger.debug('waiting in queue for runner=%s key=%s', platform.name, resourceLockKey);
-    },
-    onStillWaiting: (elapsedMs) => {
-      if (elapsedMs - lastStillWaitingLogAt < 5000) return;
-      lastStillWaitingLogAt = elapsedMs;
-      logRunnerStillWaitingInQueue(platform);
-      sessionLogger.debug('still waiting in queue for runner=%s key=%s elapsedMs=%d', platform.name, resourceLockKey, elapsedMs);
-    },
-  });
+  const resourceLease = await diagnostics.measure(
+    'session.lock.wait',
+    () =>
+      lockManager.acquire(resourceLockKey, {
+        signal: setupController.signal,
+        onWait: () => {
+          didWaitForResourceLock = true;
+          logRunnerWaitingInQueue(platform);
+          sessionLogger.debug('waiting in queue for runner=%s key=%s', platform.name, resourceLockKey);
+        },
+        onStillWaiting: (elapsedMs) => {
+          if (elapsedMs - lastStillWaitingLogAt < 5000) return;
+          lastStillWaitingLogAt = elapsedMs;
+          logRunnerStillWaitingInQueue(platform);
+          sessionLogger.debug('still waiting in queue for runner=%s key=%s elapsedMs=%d', platform.name, resourceLockKey, elapsedMs);
+        },
+      }),
+    { lockKey: resourceLockKey }
+  );
 
   if (didWaitForResourceLock) logRunnerStarting(platform);
   sessionLogger.debug('resource lock acquired for runner=%s key=%s', platform.name, resourceLockKey);
@@ -468,11 +487,22 @@ export const createHarnessSession = async (
   let metroPortLease: ResourceLease | null = null;
 
   try {
-    const resolution = await resolveHarnessMetroPort({
-      config: harnessConfig,
-      platform,
-      resourceLockManager: lockManager,
-      signal: setupController.signal,
+    const portResolveSpan = diagnostics.start('session.port.resolve');
+    let resolution: Awaited<ReturnType<typeof resolveHarnessMetroPort>>;
+    try {
+      resolution = await resolveHarnessMetroPort({
+        config: harnessConfig,
+        platform,
+        resourceLockManager: lockManager,
+        signal: setupController.signal,
+      });
+    } catch (error) {
+      portResolveSpan.fail(error);
+      throw error;
+    }
+    portResolveSpan.end({
+      port: resolution.config.metroPort,
+      didFallback: resolution.didFallback,
     });
     metroPortLease = resolution.metroPortLease;
     const { config: runtimeConfig, initialMetroPort, didFallback } = resolution;
@@ -504,11 +534,13 @@ export const createHarnessSession = async (
       rootDir: path.join(projectRoot, '.harness', 'crash-reports'),
     });
 
-    const bridge = await createHarnessBridge({
-      noServer: true,
-      timeout: runtimeConfig.bridgeTimeout,
-      context,
-    });
+    const bridge = await diagnostics.measure('session.bridge.init', () =>
+      createHarnessBridge({
+        noServer: true,
+        timeout: runtimeConfig.bridgeTimeout,
+        context,
+      })
+    );
     sessionLogger.debug('bridge initialized on Metro websocket path %s', HARNESS_BRIDGE_PATH);
 
     let metroInstance: MetroInstance;
@@ -516,34 +548,42 @@ export const createHarnessSession = async (
 
     try {
       [metroInstance, platformInstance] = await Promise.all([
-        getMetroInstance(
-          {
-            projectRoot,
-            harnessConfig: runtimeConfig,
-            websocketEndpoints: {
-              [HARNESS_BRIDGE_PATH]: bridge.ws as unknown as MetroWebSocketEndpoint,
+        diagnostics.measure('metro.init', () =>
+          getMetroInstance(
+            {
+              projectRoot,
+              harnessConfig: runtimeConfig,
+              websocketEndpoints: {
+                [HARNESS_BRIDGE_PATH]: bridge.ws as unknown as MetroWebSocketEndpoint,
+              },
             },
-          },
-          setupController.signal,
-        ).then((instance) => {
-          sessionLogger.debug('Metro initialized');
-          return instance;
-        }),
-        withPlatformReadyTimeout({
-          timeout: runtimeConfig.platformReadyTimeout,
-          signal: setupController.signal,
-          work: async (signal) => {
-            return await import(platform.runner).then((module) =>
-              module.default(platform.config, runtimeConfig, {
-                signal,
-                crashArtifactWriter,
-              } satisfies HarnessPlatformInitOptions),
-            ).then((instance) => {
-              sessionLogger.debug('platform runner initialized');
-              return instance;
-            });
-          },
-        }),
+            setupController.signal,
+          ).then((instance) => {
+            sessionLogger.debug('Metro initialized');
+            return instance;
+          })
+        ),
+        diagnostics.measure(
+          'platform.init',
+          () =>
+            withPlatformReadyTimeout({
+              timeout: runtimeConfig.platformReadyTimeout,
+              signal: setupController.signal,
+              work: async (signal) => {
+                return await import(platform.runner).then((module) =>
+                  module.default(platform.config, runtimeConfig, {
+                    signal,
+                    crashArtifactWriter,
+                    diagnostics,
+                  } satisfies HarnessPlatformInitOptions),
+                ).then((instance) => {
+                  sessionLogger.debug('platform runner initialized');
+                  return instance;
+                });
+              },
+            }),
+          { runner: platform.runner, platformId: platform.platformId }
+        ),
       ]);
     } catch (error) {
       // Only bridge needs cleanup here; leases are released by the outer catch.
@@ -568,7 +608,9 @@ export const createHarnessSession = async (
     const restartAppSession = async (): Promise<AppSession> => {
       await crashMonitor.stop();
       await disposeCurrentAppSession();
-      const session = await platformInstance.createAppSession(appLaunchOptions);
+      const session = await diagnostics.measure('app.session.create', () =>
+        platformInstance.createAppSession(appLaunchOptions)
+      );
       currentAppSession = session;
       crashMonitor.setAppSession(session);
       await crashMonitor.start();
@@ -641,6 +683,9 @@ export const createHarnessSession = async (
       metroInstance.events.addListener(clientLogListener);
     }
 
+    const disposeMetroDiagnostics = observeMetroEvents(metroInstance.events, diagnostics);
+    const disposeBridgeDiagnostics = observeBridgeEvents(bridge, diagnostics);
+
     sessionLogger.debug('registered runtime, bridge, and Metro listeners');
 
     // --- Dispose ---
@@ -649,6 +694,7 @@ export const createHarnessSession = async (
 
     const disposeOnce = async (reason: 'normal' | 'abort' | 'error') => {
       sessionLogger.debug('disposing session (reason=%s)', reason);
+      const disposeSpan = diagnostics.start('dispose.total', { reason });
       let hookError: unknown;
 
       try {
@@ -681,6 +727,8 @@ export const createHarnessSession = async (
       bridge.off('disconnected', onDisconnected);
       bridge.off('event', bridgeEventListener);
       bridge.off('event', onTestRunnerEvent);
+      disposeMetroDiagnostics();
+      disposeBridgeDiagnostics();
 
       const nativeCoverageConfig = runtimeConfig.coverage?.native?.ios;
       if (nativeCoverageConfig?.pods?.length && platformInstance.collectNativeCoverage) {
@@ -718,8 +766,15 @@ export const createHarnessSession = async (
 
       sessionLogger.debug('session resources disposed');
 
-      if (hookError) throw hookError;
-      if (cleanupError) throw cleanupError;
+      if (hookError) {
+        disposeSpan.fail(hookError);
+        throw hookError;
+      }
+      if (cleanupError) {
+        disposeSpan.fail(cleanupError);
+        throw cleanupError;
+      }
+      disposeSpan.end();
     };
 
     const dispose = (reason: 'normal' | 'abort' | 'error' = 'normal') => {
@@ -756,6 +811,10 @@ export const createHarnessSession = async (
     }
 
     logTestEnvironmentReady(platform);
+    diagnostics.record({
+      label: 'session.setup',
+      duration: Date.now() - setupStartedAt,
+    });
     sessionLogger.debug('session ready');
 
     // --- Public API ---
@@ -763,45 +822,63 @@ export const createHarnessSession = async (
     const ensureAppReady = async (testFilePath: string): Promise<void> => {
       await hooks.drain();
       sessionLogger.debug('ensuring app is ready for %s', testFilePath);
+      const appReadySpan = diagnostics.start('app.ready.total');
 
       if (crashMonitor.isAlive() && bridge.connection !== null && currentAppSession) {
         const state = await currentAppSession.getState();
         if (state.status === 'running') {
           sessionLogger.debug('reusing existing ready app for %s', testFilePath);
+          appReadySpan.end({ file: testFilePath, reused: true });
           return;
         }
       }
 
       crashMonitor.reset();
       sessionLogger.debug('app not ready, waiting for launch and runtime readiness');
-      await waitForAppReady(appReadyBaseOptions, testFilePath);
+      try {
+        await waitForAppReady(appReadyBaseOptions, testFilePath);
+      } catch (error) {
+        appReadySpan.fail(error, { file: testFilePath, reused: false });
+        throw error;
+      }
       await hooks.drain();
       sessionLogger.debug('app is ready for %s', testFilePath);
+      appReadySpan.end({ file: testFilePath, reused: false });
     };
 
     const restartApp = async (testFilePath?: string): Promise<void> => {
       await hooks.drain();
       await crashMonitor.stop();
+      const reason: 'stop-and-ensure-ready' | 'direct-restart' = testFilePath
+        ? 'stop-and-ensure-ready'
+        : 'direct-restart';
       sessionLogger.debug(
         'restarting app (testFile=%s mode=%s)',
         testFilePath ?? 'n/a',
-        testFilePath ? 'stop-and-ensure-ready' : 'direct-restart',
+        reason,
       );
+      const restartSpan = diagnostics.start('app.restart', { reason });
 
-      await disposeCurrentAppSession();
+      try {
+        await disposeCurrentAppSession();
 
-      if (testFilePath) {
-        await ensureAppReady(testFilePath);
-      } else {
-        const session = await platformInstance.createAppSession(appLaunchOptions);
-        currentAppSession = session;
-        crashMonitor.setAppSession(session);
-        crashMonitor.reset();
-        await crashMonitor.start();
+        if (testFilePath) {
+          await ensureAppReady(testFilePath);
+        } else {
+          const session = await platformInstance.createAppSession(appLaunchOptions);
+          currentAppSession = session;
+          crashMonitor.setAppSession(session);
+          crashMonitor.reset();
+          await crashMonitor.start();
+        }
+
+        await hooks.drain();
+        sessionLogger.debug('restart completed');
+        restartSpan.end();
+      } catch (error) {
+        restartSpan.fail(error);
+        throw error;
       }
-
-      await hooks.drain();
-      sessionLogger.debug('restart completed');
     };
 
     const runTestFile = async (
@@ -857,6 +934,7 @@ export const createHarnessSession = async (
     return {
       config: runtimeConfig,
       context,
+      diagnostics,
       onTestRunnerEvent: (listener) => {
         testRunnerEventListeners.add(listener);
         return () => {
@@ -870,7 +948,11 @@ export const createHarnessSession = async (
       flushClientLogs,
       callHook: async (name, payload) => {
         await hooks.drain();
-        await pluginManager.callHook(name, payload);
+        await diagnostics.measure(
+          'plugin.hook',
+          () => pluginManager.callHook(name, payload),
+          { hook: String(name) }
+        );
         await hooks.drain();
       },
       setRunState: (state) => {

--- a/packages/platform-android/src/instance.ts
+++ b/packages/platform-android/src/instance.ts
@@ -5,7 +5,7 @@ import {
   HarnessPlatformRunner,
 } from '@react-native-harness/platforms';
 import type { Config as HarnessConfig } from '@react-native-harness/config';
-import { logger } from '@react-native-harness/tools';
+import { instrumented, logger, noopDiagnostics } from '@react-native-harness/tools';
 import {
   AndroidPlatformConfig,
   assertAndroidDeviceEmulator,
@@ -17,7 +17,7 @@ import {
   resolveAvdCachingEnabled,
 } from './avd-config.js';
 import { getAdbId } from './adb-id.js';
-import * as adb from './adb.js';
+import * as adbModule from './adb.js';
 import {
   applyHarnessDebugHttpHost,
   clearHarnessDebugHttpHost,
@@ -71,13 +71,13 @@ const configureAndroidRuntime = async (
   const metroPort = harnessConfig.metroPort;
 
   await Promise.all([
-    adb.reversePort(adbId, metroPort),
-    adb.reversePort(adbId, 8080),
-    adb.setHideErrorDialogs(adbId, true),
+    adbModule.reversePort(adbId, metroPort),
+    adbModule.reversePort(adbId, 8080),
+    adbModule.setHideErrorDialogs(adbId, true),
     applyHarnessDebugHttpHost(adbId, config.bundleId, `localhost:${metroPort}`),
   ]);
 
-  return adb.getAppUid(adbId, config.bundleId);
+  return adbModule.getAppUid(adbId, config.bundleId);
 };
 
 const startAndWaitForBoot = async ({
@@ -87,11 +87,11 @@ const startAndWaitForBoot = async ({
 }: {
   emulatorName: string;
   signal: AbortSignal;
-  mode?: Parameters<typeof adb.startEmulator>[1];
+  mode?: Parameters<typeof adbModule.startEmulator>[1];
 }): Promise<string> => {
   await ensureAndroidEmulatorAvailable();
-  await adb.startEmulator(emulatorName, mode);
-  return adb.waitForBoot(emulatorName, signal);
+  await adbModule.startEmulator(emulatorName, mode);
+  return adbModule.waitForBoot(emulatorName, signal);
 };
 
 const recreateAvd = async ({
@@ -106,7 +106,7 @@ const recreateAvd = async ({
     throw new HarnessEmulatorConfigError(emulatorConfig.name);
   }
 
-  await adb.createAvd({
+  await adbModule.createAvd({
     name: emulatorConfig.name,
     apiLevel: emulatorConfig.avd.apiLevel,
     profile: emulatorConfig.avd.profile,
@@ -127,7 +127,7 @@ const prepareCachedAvd = async ({
 }): Promise<string> => {
   const emulatorName = emulatorConfig.name;
   const hostArch = getHostAndroidSystemImageArch();
-  const hasExistingAvd = await adb.hasAvd(emulatorName);
+  const hasExistingAvd = await adbModule.hasAvd(emulatorName);
   const avdConfig = hasExistingAvd ? await readAvdConfig(emulatorName) : null;
   const compatibility =
     avdConfig == null
@@ -152,7 +152,7 @@ const prepareCachedAvd = async ({
         emulatorName,
         compatibility.reason
       );
-      await adb.deleteAvd(emulatorName);
+      await adbModule.deleteAvd(emulatorName);
     }
 
     await recreateAvd({ emulatorConfig });
@@ -164,8 +164,8 @@ const prepareCachedAvd = async ({
     });
 
     logger.info('Saving Android emulator snapshot for %s...', emulatorName);
-    await adb.stopEmulator(generationAdbId);
-    await adb.waitForEmulatorDisconnect(generationAdbId, signal);
+    await adbModule.stopEmulator(generationAdbId);
+    await adbModule.waitForEmulatorDisconnect(generationAdbId, signal);
   } else {
     logger.info('Using cached Android emulator %s...', emulatorName);
   }
@@ -183,6 +183,11 @@ export const getAndroidEmulatorPlatformInstance = async (
   init: HarnessPlatformInitOptions
 ): Promise<HarnessPlatformRunner> => {
   assertAndroidDeviceEmulator(config.device);
+  const adb = instrumented(
+    adbModule,
+    'platform.android.adb',
+    init.diagnostics ?? noopDiagnostics
+  );
   const permissionsEnabled = harnessConfig.permissions ?? false;
   const emulatorConfig = config.device;
   const emulatorName = emulatorConfig.name;
@@ -315,6 +320,11 @@ export const getAndroidPhysicalDevicePlatformInstance = async (
   init?: HarnessPlatformInitOptions
 ): Promise<HarnessPlatformRunner> => {
   assertAndroidDevicePhysical(config.device);
+  const adb = instrumented(
+    adbModule,
+    'platform.android.adb',
+    init?.diagnostics ?? noopDiagnostics
+  );
   const permissionsEnabled = harnessConfig.permissions ?? false;
 
   const adbId = await getAdbId(config.device);

--- a/packages/platform-ios/src/instance.ts
+++ b/packages/platform-ios/src/instance.ts
@@ -14,11 +14,11 @@ import {
   assertAppleDevicePhysical,
   assertAppleDeviceSimulator,
 } from './config.js';
-import * as simctl from './xcrun/simctl.js';
-import * as devicectl from './xcrun/devicectl.js';
+import * as simctlModule from './xcrun/simctl.js';
+import * as devicectlModule from './xcrun/devicectl.js';
 import { getDeviceName } from './utils.js';
 import { HarnessAppPathError } from './errors.js';
-import { logger } from '@react-native-harness/tools';
+import { instrumented, logger, noopDiagnostics } from '@react-native-harness/tools';
 import fs from 'node:fs';
 import { createXCTestAgentController } from './xctest-agent.js';
 import { createPermissionPromptAutoAcceptCapability } from './xctest-agent-capabilities.js';
@@ -54,6 +54,11 @@ export const getAppleSimulatorPlatformInstance = async (
   init: HarnessPlatformInitOptions
 ): Promise<HarnessPlatformRunner> => {
   assertAppleDeviceSimulator(config.device);
+  const simctl = instrumented(
+    simctlModule,
+    'platform.ios.simctl',
+    init.diagnostics ?? noopDiagnostics
+  );
   const permissionsEnabled = harnessConfig.permissions ?? false;
 
   if (harnessConfig.coverage?.native?.ios?.pods?.length) {
@@ -204,6 +209,11 @@ export const getApplePhysicalDevicePlatformInstance = async (
   init?: HarnessPlatformInitOptions
 ): Promise<HarnessPlatformRunner> => {
   assertAppleDevicePhysical(config.device);
+  const devicectl = instrumented(
+    devicectlModule,
+    'platform.ios.devicectl',
+    init?.diagnostics ?? noopDiagnostics
+  );
   const permissionsEnabled = harnessConfig.permissions ?? false;
 
   if (harnessConfig.metroPort !== DEFAULT_METRO_PORT) {

--- a/packages/platforms/package.json
+++ b/packages/platforms/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "@react-native-harness/tools": "workspace:*",
     "tslib": "^2.3.0"
   },
   "license": "MIT"

--- a/packages/platforms/src/types.ts
+++ b/packages/platforms/src/types.ts
@@ -1,3 +1,5 @@
+import type { Diagnostics } from '@react-native-harness/tools';
+
 export type CrashArtifactKind =
   | 'logcat'
   | 'ios-crash-report'
@@ -125,6 +127,12 @@ export type HarnessPlatformRunner = {
 export type HarnessPlatformInitOptions = {
   signal: AbortSignal;
   crashArtifactWriter?: CrashArtifactWriter;
+  /**
+   * Optional diagnostics tracing handle. Platform runners may use this to
+   * instrument subsystems (e.g. adb/simctl/devicectl) via `instrumented()`.
+   * Omitted or a disabled instance when diagnostics tracing is off.
+   */
+  diagnostics?: Diagnostics;
 };
 
 export type HarnessCliCommandContext = {

--- a/packages/platforms/tsconfig.json
+++ b/packages/platforms/tsconfig.json
@@ -4,6 +4,9 @@
   "include": [],
   "references": [
     {
+      "path": "../tools"
+    },
+    {
       "path": "./tsconfig.lib.json"
     }
   ]

--- a/packages/platforms/tsconfig.lib.json
+++ b/packages/platforms/tsconfig.lib.json
@@ -10,5 +10,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../tools/tsconfig.lib.json"
+    }
+  ]
 }

--- a/packages/tools/eslint.config.mjs
+++ b/packages/tools/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
       '@nx/dependency-checks': [
         'error',
         {
+          ignoredDependencies: ['vite', 'vitest'],
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
             '{projectRoot}/src/**/__tests__/**',

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -24,7 +24,8 @@
     "react-native": "*"
   },
   "devDependencies": {
-    "react-native": "*"
+    "react-native": "*",
+    "vite": "^7.2.2"
   },
   "license": "MIT"
 }

--- a/packages/tools/src/__tests__/diagnostics.test.ts
+++ b/packages/tools/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDiagnostics, instrumented } from '../diagnostics.js';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('createDiagnostics (enabled)', () => {
+  it('measures a successful sync/async fn', async () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+
+    const result = await diagnostics.measure('foo.bar', async () => {
+      await wait(5);
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.label).toBe('foo.bar');
+    expect(entries[0]?.status).toBe('ok');
+    expect(entries[0]?.kind).toBe('span');
+    expect(entries[0]?.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records an error status and rethrows on measure failure', async () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const error = new Error('boom');
+
+    await expect(
+      diagnostics.measure('foo.bar', () => {
+        throw error;
+      })
+    ).rejects.toThrow('boom');
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.status).toBe('error');
+    expect(entries[0]?.attrs?.error).toBe('Error: boom');
+  });
+
+  it('spans end() is idempotent', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const span = diagnostics.start('foo.span');
+    span.end({ a: 1 });
+    span.end({ a: 2 });
+    span.fail(new Error('nope'));
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.attrs).toEqual({ a: 1 });
+  });
+
+  it('spans fail() is idempotent and truncates long errors', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const span = diagnostics.start('foo.span');
+    const longMessage = 'x'.repeat(300);
+    span.fail(new Error(longMessage));
+    span.end();
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.status).toBe('error');
+    expect(entries[0]?.attrs?.error).toHaveLength(203);
+  });
+
+  it('child(namespace) prefixes labels and writes to the root buffer', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const metro = diagnostics.child('metro');
+    metro.mark('bundle.request');
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.label).toBe('metro.bundle.request');
+  });
+
+  it('child(attrs) merges inherited attrs into every entry', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const withRunId = diagnostics.child({ runId: 'run-1' });
+    withRunId.mark('run.total', { status: 'ok' });
+
+    const entries = diagnostics.flush();
+    expect(entries[0]?.attrs).toEqual({ runId: 'run-1', status: 'ok' });
+  });
+
+  it('mark() records an instant entry with zero duration', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    diagnostics.mark('bridge.connected');
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.kind).toBe('mark');
+    expect(entries[0]?.duration).toBe(0);
+  });
+
+  it('record() computes startTime from now - duration', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const before = Date.now();
+    diagnostics.record({ label: 'client.test', duration: 100 });
+    const after = Date.now();
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.duration).toBe(100);
+    expect(entries[0]?.startTime).toBeGreaterThanOrEqual(before - 100 - 5);
+    expect(entries[0]?.startTime).toBeLessThanOrEqual(after - 100 + 5);
+  });
+
+  it('flush() drains recorded entries', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    diagnostics.mark('a');
+    expect(diagnostics.flush()).toHaveLength(1);
+    expect(diagnostics.flush()).toHaveLength(0);
+  });
+});
+
+describe('createDiagnostics (disabled)', () => {
+  it('is a no-op: measure just invokes fn, flush returns empty', async () => {
+    const diagnostics = createDiagnostics({ enabled: false });
+    expect(diagnostics.enabled).toBe(false);
+
+    const result = await diagnostics.measure('foo', async () => 'value');
+    expect(result).toBe('value');
+    expect(diagnostics.flush()).toEqual([]);
+
+    const span = diagnostics.start('foo');
+    span.end();
+    span.fail(new Error('x'));
+    diagnostics.mark('foo');
+    diagnostics.record({ label: 'foo', duration: 10 });
+    expect(diagnostics.flush()).toEqual([]);
+  });
+
+  it('defaults to disabled when no options are passed', () => {
+    const diagnostics = createDiagnostics();
+    expect(diagnostics.enabled).toBe(false);
+  });
+
+  it('child() of a disabled instance is also disabled', () => {
+    const diagnostics = createDiagnostics({ enabled: false });
+    const child = diagnostics.child('ns');
+    expect(child.enabled).toBe(false);
+  });
+});
+
+describe('instrumented()', () => {
+  it('returns the same reference when diagnostics is disabled', () => {
+    const target = { doThing: () => 'ok' };
+    const diagnostics = createDiagnostics({ enabled: false });
+    expect(instrumented(target, 'ns', diagnostics)).toBe(target);
+  });
+
+  it('times a successful async method', async () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const target = {
+      doThing: async (n: number) => {
+        await wait(5);
+        return n * 2;
+      },
+    };
+
+    const wrapped = instrumented(target, 'platform.android.adb', diagnostics);
+    await expect(wrapped.doThing(21)).resolves.toBe(42);
+
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.label).toBe('platform.android.adb.doThing');
+    expect(entries[0]?.status).toBe('ok');
+  });
+
+  it('records a failed async method and rethrows', async () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const target = {
+      doThing: async () => {
+        throw new Error('fail');
+      },
+    };
+
+    const wrapped = instrumented(target, 'ns', diagnostics);
+    await expect(wrapped.doThing()).rejects.toThrow('fail');
+
+    const entries = diagnostics.flush();
+    expect(entries[0]?.status).toBe('error');
+  });
+
+  it('records a failed sync method and rethrows', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const target = {
+      doThing: () => {
+        throw new Error('sync fail');
+      },
+    };
+
+    const wrapped = instrumented(target, 'ns', diagnostics);
+    expect(() => wrapped.doThing()).toThrow('sync fail');
+
+    const entries = diagnostics.flush();
+    expect(entries[0]?.status).toBe('error');
+  });
+
+  it('passes through non-function properties untouched', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const target = { value: 123 };
+    const wrapped = instrumented(target, 'ns', diagnostics);
+    expect(wrapped.value).toBe(123);
+  });
+
+  it('preserves this binding for wrapped methods', async () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const target = {
+      state: 7,
+      getState() {
+        return this.state;
+      },
+    };
+
+    const wrapped = instrumented(target, 'ns', diagnostics);
+    expect(wrapped.getState()).toBe(7);
+  });
+
+  it('keeps a stable identity for wrapped methods so listener add/remove works', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const target = { handler: () => undefined };
+    const wrapped = instrumented(target, 'ns', diagnostics);
+
+    const first = wrapped.handler;
+    const second = wrapped.handler;
+    expect(first).toBe(second);
+
+    const listeners = new Set<() => void>();
+    listeners.add(wrapped.handler);
+    listeners.delete(wrapped.handler);
+    expect(listeners.size).toBe(0);
+  });
+
+  it('spy-based check that fn is invoked once per call', () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const spy = vi.fn(() => 'ok');
+    const target = { doThing: spy };
+    const wrapped = instrumented(target, 'ns', diagnostics);
+
+    wrapped.doThing();
+    wrapped.doThing();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tools/src/diagnostics.ts
+++ b/packages/tools/src/diagnostics.ts
@@ -1,0 +1,281 @@
+export type DiagnosticAttrs = Record<string, string | number | boolean | undefined>;
+
+export type DiagnosticEntry = {
+  label: string;
+  startTime: number; // ms epoch
+  duration: number; // ms
+  attrs?: DiagnosticAttrs;
+  status: 'ok' | 'error';
+  kind: 'span' | 'mark';
+};
+
+export type DiagnosticSpan = {
+  end(attrs?: DiagnosticAttrs): void;
+  fail(error: unknown, attrs?: DiagnosticAttrs): void;
+};
+
+export type DiagnosticRecordInput = {
+  label: string;
+  duration: number;
+  attrs?: DiagnosticAttrs;
+  status?: 'ok' | 'error';
+};
+
+export type Diagnostics = {
+  readonly enabled: boolean;
+  start(label: string, attrs?: DiagnosticAttrs): DiagnosticSpan;
+  measure<T>(label: string, fn: () => T | Promise<T>, attrs?: DiagnosticAttrs): Promise<T>;
+  mark(label: string, attrs?: DiagnosticAttrs): void;
+  record(entry: DiagnosticRecordInput): void;
+  child(nsOrAttrs: string | DiagnosticAttrs): Diagnostics;
+  flush(): DiagnosticEntry[];
+};
+
+const MAX_ERROR_ATTR_LENGTH = 200;
+
+const truncateError = (error: unknown): string => {
+  const message = String(error);
+  return message.length > MAX_ERROR_ATTR_LENGTH
+    ? `${message.slice(0, MAX_ERROR_ATTR_LENGTH)}...`
+    : message;
+};
+
+const mergeAttrs = (
+  base: DiagnosticAttrs | undefined,
+  extra: DiagnosticAttrs | undefined
+): DiagnosticAttrs | undefined => {
+  if (!base && !extra) {
+    return undefined;
+  }
+
+  return { ...base, ...extra };
+};
+
+const noop = (): void => undefined;
+
+const noopSpan: DiagnosticSpan = {
+  end: noop,
+  fail: noop,
+};
+
+const createNoopDiagnostics = (): Diagnostics => {
+  const diagnostics: Diagnostics = {
+    enabled: false,
+    start: () => noopSpan,
+    measure: async (_label, fn) => fn(),
+    mark: noop,
+    record: noop,
+    child: () => diagnostics,
+    flush: () => [],
+  };
+
+  return diagnostics;
+};
+
+export const noopDiagnostics: Diagnostics = createNoopDiagnostics();
+
+type RootState = {
+  entries: DiagnosticEntry[];
+  epochAnchor: number;
+  perfAnchor: number;
+};
+
+const now = (state: RootState): number =>
+  state.epochAnchor + (performance.now() - state.perfAnchor);
+
+const createEnabledDiagnostics = (
+  state: RootState,
+  namespace: string,
+  inheritedAttrs: DiagnosticAttrs | undefined
+): Diagnostics => {
+  const prefixLabel = (label: string): string =>
+    namespace ? `${namespace}.${label}` : label;
+
+  const pushEntry = (entry: DiagnosticEntry) => {
+    state.entries.push(entry);
+  };
+
+  const start = (label: string, attrs?: DiagnosticAttrs): DiagnosticSpan => {
+    const fullLabel = prefixLabel(label);
+    const startTime = now(state);
+    const startPerf = performance.now();
+    let settled = false;
+
+    return {
+      end: (endAttrs?: DiagnosticAttrs) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        pushEntry({
+          label: fullLabel,
+          startTime,
+          duration: performance.now() - startPerf,
+          attrs: mergeAttrs(mergeAttrs(inheritedAttrs, attrs), endAttrs),
+          status: 'ok',
+          kind: 'span',
+        });
+      },
+      fail: (error: unknown, failAttrs?: DiagnosticAttrs) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        pushEntry({
+          label: fullLabel,
+          startTime,
+          duration: performance.now() - startPerf,
+          attrs: mergeAttrs(mergeAttrs(mergeAttrs(inheritedAttrs, attrs), failAttrs), {
+            error: truncateError(error),
+          }),
+          status: 'error',
+          kind: 'span',
+        });
+      },
+    };
+  };
+
+  const measure = async <T>(
+    label: string,
+    fn: () => T | Promise<T>,
+    attrs?: DiagnosticAttrs
+  ): Promise<T> => {
+    const span = start(label, attrs);
+    try {
+      const result = await fn();
+      span.end();
+      return result;
+    } catch (error) {
+      span.fail(error);
+      throw error;
+    }
+  };
+
+  const mark = (label: string, attrs?: DiagnosticAttrs): void => {
+    pushEntry({
+      label: prefixLabel(label),
+      startTime: now(state),
+      duration: 0,
+      attrs: mergeAttrs(inheritedAttrs, attrs),
+      status: 'ok',
+      kind: 'mark',
+    });
+  };
+
+  const record = (entry: DiagnosticRecordInput): void => {
+    pushEntry({
+      label: prefixLabel(entry.label),
+      startTime: now(state) - entry.duration,
+      duration: entry.duration,
+      attrs: mergeAttrs(inheritedAttrs, entry.attrs),
+      status: entry.status ?? 'ok',
+      kind: 'span',
+    });
+  };
+
+  const child = (nsOrAttrs: string | DiagnosticAttrs): Diagnostics => {
+    if (typeof nsOrAttrs === 'string') {
+      const childNamespace = namespace ? `${namespace}.${nsOrAttrs}` : nsOrAttrs;
+      return createEnabledDiagnostics(state, childNamespace, inheritedAttrs);
+    }
+
+    return createEnabledDiagnostics(
+      state,
+      namespace,
+      mergeAttrs(inheritedAttrs, nsOrAttrs)
+    );
+  };
+
+  const flush = (): DiagnosticEntry[] => {
+    const flushed = state.entries;
+    state.entries = [];
+    return flushed;
+  };
+
+  return {
+    enabled: true,
+    start,
+    measure,
+    mark,
+    record,
+    child,
+    flush,
+  };
+};
+
+export const createDiagnostics = (options?: { enabled?: boolean }): Diagnostics => {
+  if (!options?.enabled) {
+    return noopDiagnostics;
+  }
+
+  const state: RootState = {
+    entries: [],
+    epochAnchor: Date.now(),
+    perfAnchor: performance.now(),
+  };
+
+  return createEnabledDiagnostics(state, '', undefined);
+};
+
+export const instrumented = <T extends object>(
+  target: T,
+  ns: string,
+  diagnostics: Diagnostics
+): T => {
+  if (!diagnostics.enabled) {
+    return target;
+  }
+
+  const wrapped = new Map<PropertyKey, (...args: unknown[]) => unknown>();
+
+  return new Proxy(target, {
+    get(obj, prop, receiver) {
+      const value = Reflect.get(obj, prop, receiver);
+
+      if (typeof value !== 'function') {
+        return value;
+      }
+
+      const cached = wrapped.get(prop);
+      if (cached) {
+        return cached;
+      }
+
+      const wrappedFn = (...args: unknown[]) => {
+        const span = diagnostics.start(`${ns}.${String(prop)}`);
+
+        let result: unknown;
+        try {
+          result = value.apply(obj, args);
+        } catch (error) {
+          span.fail(error);
+          throw error;
+        }
+
+        if (
+          result &&
+          typeof result === 'object' &&
+          'then' in result &&
+          typeof (result as { then: unknown }).then === 'function'
+        ) {
+          return (result as Promise<unknown>).then(
+            (resolved) => {
+              span.end();
+              return resolved;
+            },
+            (error: unknown) => {
+              span.fail(error);
+              throw error;
+            }
+          );
+        }
+
+        span.end();
+        return result;
+      };
+
+      wrapped.set(prop, wrappedFn);
+      return wrappedFn;
+    },
+  });
+};

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -13,3 +13,4 @@ export * from './crash-artifacts.js';
 export * from './harness-artifacts.js';
 export * from './regex.js';
 export * from './isInteractive.js';
+export * from './diagnostics.js';

--- a/packages/tools/vite.config.ts
+++ b/packages/tools/vite.config.ts
@@ -1,0 +1,18 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/tools',
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,6 +593,9 @@ importers:
       react-native:
         specifier: '*'
         version: 0.82.1(@babel/core@7.27.4)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.82.1)(@types/react@19.1.13)(react@19.2.3)
+      vite:
+        specifier: ^7.2.2
+        version: 7.2.2(@types/node@20.19.25)(jiti@2.6.1)(terser@5.42.0)(yaml@2.8.0)
 
   packages/ui:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
 
   packages/platforms:
     dependencies:
+      '@react-native-harness/tools':
+        specifier: workspace:*
+        version: link:../tools
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
## What is this?

This PR adds opt-in diagnostics tracing to the harness test runner. Today, when a Harness run is slow, there's no way to see where the time actually went — session setup, Metro bundling, device/bridge round-trips, and per-file test execution are all opaque. This makes it hard to know whether to optimize the emulator boot path, Metro, the bridge protocol, or something else entirely.

With diagnostics enabled, every run now produces a Chrome Trace Event JSON file plus a console summary breaking down time spent by stage, so we can reason about what to optimize with actual data instead of guesswork.

## How does it work?

Diagnostics is enabled via the new `diagnostics` config option or the `RN_HARNESS_DIAGNOSTICS` env var (`isDiagnosticsEnabled` in `packages/config`). When off, everything resolves to a zero-cost noop implementation, so there's no overhead in the default path.

The core primitive lives in `packages/tools/src/diagnostics.ts`: a `Diagnostics` handle with `start`/`measure`/`mark`/`record` for spans and instants, `child()` for namespacing/attaching attrs, and `flush()` to drain buffered entries. It also exports `instrumented()`, a `Proxy`-based wrapper that auto-times every method call on a target object without touching its call sites.

From there, diagnostics is threaded through the pieces of a run:
- `harness-session.ts` spans session setup phases — resource lock wait, Metro port resolution, bridge init, Metro/platform init, app session create/restart/ready, dispose, and plugin hook calls.
- `execute-run.ts` wraps the whole run (`run.total`) and each test file (`run.file`), then on completion flushes all entries, logs a summary, and writes the trace file.
- `packages/jest/src/diagnostics/derivers.ts` derives spans/marks from existing Metro reporter events (`metro.bundle.build`, `metro.bundle.request`) and bridge/device events (`bridge.connected/disconnected`, `client.bundle.module`, `client.setup-file`, `client.collect`, `client.suite`, `client.test`) without adding diagnostics calls to business logic elsewhere.
- `platform-android`/`platform-ios` wrap their `adb`/`simctl`/`devicectl` modules with `instrumented()` at their composition roots, via a new optional `diagnostics` field on `HarnessPlatformInitOptions`, so every native tooling shell-out is timed automatically.

The trace file (`.harness/diagnostics/<runId>.json`) is written in Chrome Trace Event format and can be loaded directly in `chrome://tracing` or Perfetto for a visual timeline. The console summary (`packages/jest/src/diagnostics/report.ts`) groups entries by namespace and prints count/total/max duration per label.

## Why is this useful?

- Gives a concrete, data-backed way to answer "why is this run slow?" instead of speculating — spans cover session setup, bundling, bridge, native tooling, and per-file execution.
- Zero cost when disabled: all diagnostics calls resolve to noops unless explicitly turned on.
- The Chrome Trace output plugs into existing tooling (`chrome://tracing`, Perfetto) for visual inspection, no custom viewer needed.
- `instrumented()` lets us add timing to whole modules (adb, simctl, devicectl) at a single call site rather than instrumenting every call individually, so future instrumentation stays cheap to add.
