### PR TITLE
Match prewarm bundle URL to what clients actually request

### DIFF
--- a/.nx/version-plans/fix-prewarm-bundle-url-parity.md
+++ b/.nx/version-plans/fix-prewarm-bundle-url-parity.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fixes Metro prewarm so it actually warms the graph the app requests. On Expo projects, the prewarm request was missing several transform/query params the app's real bundle request uses, so the prewarmed graph was essentially always thrown away and rebuilt from scratch; on bare React Native it was missing `lazy=true`. Both client types now request byte-identical bundle URLs, so the prewarm work is no longer wasted, and a new guard logs a warning if the two URLs ever drift apart again.

--- a/packages/bundler-metro/src/__tests__/bundle-url.test.ts
+++ b/packages/bundler-metro/src/__tests__/bundle-url.test.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Config as HarnessConfig } from '@react-native-harness/config';
+import { getExpoMiddleware } from '../middlewares/expo-middleware.js';
+import { getResolvedEntryPointWithoutExtension } from '../entry-point-utils.js';
+import {
+  detectBundleClientProfile,
+  getBundleSearchParams,
+  getBundleUrl,
+} from '../bundle-url.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+const createProjectRoot = () => {
+  const projectRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'rn-harness-bundle-url-')
+  );
+  tempDirs.push(projectRoot);
+  fs.writeFileSync(path.join(projectRoot, 'index.js'), 'module.exports = {};');
+  return projectRoot;
+};
+
+const writeExpoPackage = (projectRoot: string) => {
+  const expoDir = path.join(projectRoot, 'node_modules', 'expo');
+  fs.mkdirSync(expoDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(expoDir, 'package.json'),
+    JSON.stringify({ name: 'expo', version: '0.0.0', main: 'index.js' })
+  );
+  fs.writeFileSync(path.join(expoDir, 'index.js'), 'module.exports = {};');
+};
+
+const createHarnessConfig = (metroPort: number): HarnessConfig =>
+  ({
+    entryPoint: './index.js',
+    metroPort,
+  } as HarnessConfig);
+
+// Capture a fake req/res pair and return the launchAsset URL served by the
+// Expo manifest middleware.
+const getManifestLaunchAssetUrl = (
+  projectRoot: string,
+  harnessConfig: HarnessConfig,
+  platform: string
+): string => {
+  const middleware = getExpoMiddleware(projectRoot, harnessConfig);
+
+  let body = '';
+  const res = {
+    statusCode: 0,
+    setHeader: () => undefined,
+    end: (chunk?: string) => {
+      if (chunk) {
+        body = chunk;
+      }
+    },
+  };
+
+  middleware(
+    {
+      url: '/',
+      method: 'GET',
+      headers: { 'expo-platform': platform },
+    } as never,
+    res as never,
+    () => undefined
+  );
+
+  const manifest = JSON.parse(body);
+  return manifest.launchAsset.url as string;
+};
+
+describe('getBundleUrl', () => {
+  it('produces an expo-profile URL byte-identical to the manifest served by getExpoMiddleware', () => {
+    const projectRoot = createProjectRoot();
+    const harnessConfig = createHarnessConfig(8081);
+
+    const manifestUrl = getManifestLaunchAssetUrl(
+      projectRoot,
+      harnessConfig,
+      'ios'
+    );
+    const resolvedEntryPoint = getResolvedEntryPointWithoutExtension(
+      projectRoot,
+      harnessConfig.entryPoint
+    );
+
+    const builtUrl = getBundleUrl({
+      port: harnessConfig.metroPort,
+      resolvedEntryPoint,
+      platform: 'ios',
+      profile: 'expo',
+    });
+
+    expect(builtUrl).toBe(manifestUrl);
+    expect(manifestUrl).toBe(
+      `http://localhost:8081/${resolvedEntryPoint}.bundle?platform=ios&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&transform.reactCompiler=true&unstable_transformProfile=hermes-stable`
+    );
+  });
+
+  it('produces bare-profile params matching bare RN dev clients', () => {
+    const params = getBundleSearchParams('bare', 'android');
+
+    expect(params.toString()).toBe(
+      'platform=android&dev=true&minify=false&lazy=true'
+    );
+  });
+
+  it('builds a bare-profile URL', () => {
+    const url = getBundleUrl({
+      port: 8081,
+      resolvedEntryPoint: 'index',
+      platform: 'android',
+      profile: 'bare',
+    });
+
+    expect(url).toBe(
+      'http://localhost:8081/index.bundle?platform=android&dev=true&minify=false&lazy=true'
+    );
+  });
+});
+
+describe('detectBundleClientProfile', () => {
+  it('detects a managed Expo project (app.json with expo key + resolvable expo)', () => {
+    const projectRoot = createProjectRoot();
+    fs.writeFileSync(
+      path.join(projectRoot, 'app.json'),
+      JSON.stringify({ expo: { name: 'my-app' } })
+    );
+    writeExpoPackage(projectRoot);
+
+    expect(detectBundleClientProfile(projectRoot)).toBe('expo');
+  });
+
+  it('detects an Expo project via app.config.js + resolvable expo', () => {
+    const projectRoot = createProjectRoot();
+    fs.writeFileSync(
+      path.join(projectRoot, 'app.config.js'),
+      'module.exports = { expo: { name: "my-app" } };'
+    );
+    writeExpoPackage(projectRoot);
+
+    expect(detectBundleClientProfile(projectRoot)).toBe('expo');
+  });
+
+  it('treats a bare RN project (app.json without expo key) as bare', () => {
+    const projectRoot = createProjectRoot();
+    fs.writeFileSync(
+      path.join(projectRoot, 'app.json'),
+      JSON.stringify({ name: 'my-app', displayName: 'My App' })
+    );
+
+    expect(detectBundleClientProfile(projectRoot)).toBe('bare');
+  });
+
+  it('treats a bare project with expo resolvable but no expo config as bare', () => {
+    const projectRoot = createProjectRoot();
+    fs.writeFileSync(
+      path.join(projectRoot, 'app.json'),
+      JSON.stringify({ name: 'my-app', displayName: 'My App' })
+    );
+    writeExpoPackage(projectRoot);
+
+    expect(detectBundleClientProfile(projectRoot)).toBe('bare');
+  });
+
+  it('treats an unparseable app.json as bare', () => {
+    const projectRoot = createProjectRoot();
+    fs.writeFileSync(path.join(projectRoot, 'app.json'), '{ not valid json');
+    writeExpoPackage(projectRoot);
+
+    expect(detectBundleClientProfile(projectRoot)).toBe('bare');
+  });
+
+  it('treats a project with no app.json/app.config and no expo package as bare', () => {
+    const projectRoot = createProjectRoot();
+
+    expect(detectBundleClientProfile(projectRoot)).toBe('bare');
+  });
+});

--- a/packages/bundler-metro/src/__tests__/prewarm-guard.test.ts
+++ b/packages/bundler-metro/src/__tests__/prewarm-guard.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { diffGraphRelevantParams } from '../prewarm-guard.js';
+
+describe('diffGraphRelevantParams', () => {
+  it('reports no diff when params are identical but in a different order', () => {
+    const prewarmUrl =
+      '/index.bundle?platform=ios&dev=true&transform.engine=hermes';
+    const appUrl =
+      '/index.bundle?transform.engine=hermes&dev=true&platform=ios';
+
+    expect(diffGraphRelevantParams(prewarmUrl, appUrl)).toEqual([]);
+  });
+
+  it('ignores serializer-only params (app, sourcePaths, runModule, hot)', () => {
+    const prewarmUrl = '/index.bundle?platform=ios&dev=true';
+    const appUrl =
+      '/index.bundle?platform=ios&dev=true&app=com.example.app&sourcePaths=url-server&runModule=true&hot=false';
+
+    expect(diffGraphRelevantParams(prewarmUrl, appUrl)).toEqual([]);
+  });
+
+  it('treats an omitted param as equal to its explicit Metro default', () => {
+    const prewarmUrl = '/index.bundle?platform=ios';
+    const appUrl = '/index.bundle?platform=ios&dev=true';
+
+    expect(diffGraphRelevantParams(prewarmUrl, appUrl)).toEqual([]);
+  });
+
+  it('reports a diff naming the key when lazy differs', () => {
+    const prewarmUrl = '/index.bundle?platform=ios&dev=true&lazy=true';
+    const appUrl = '/index.bundle?platform=ios&dev=true&lazy=false';
+
+    const diffs = diffGraphRelevantParams(prewarmUrl, appUrl);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]).toContain('lazy');
+  });
+
+  it('reports a diff naming the key when transform.engine differs', () => {
+    const prewarmUrl =
+      '/index.bundle?platform=ios&dev=true&transform.engine=hermes';
+    const appUrl = '/index.bundle?platform=ios&dev=true';
+
+    const diffs = diffGraphRelevantParams(prewarmUrl, appUrl);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]).toContain('transform.engine');
+  });
+
+  it('reports a diff naming pathname when entry files differ', () => {
+    const prewarmUrl = '/index.bundle?platform=ios&dev=true';
+    const appUrl = '/.expo/.virtual-metro-entry.bundle?platform=ios&dev=true';
+
+    const diffs = diffGraphRelevantParams(prewarmUrl, appUrl);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]).toContain('pathname');
+  });
+
+  it('never throws on malformed URLs', () => {
+    const malformed = 'http://[not-a-valid-host';
+    expect(() => diffGraphRelevantParams(malformed, malformed)).not.toThrow();
+    expect(diffGraphRelevantParams(malformed, malformed)).toEqual([]);
+  });
+});

--- a/packages/bundler-metro/src/__tests__/resolver.test.ts
+++ b/packages/bundler-metro/src/__tests__/resolver.test.ts
@@ -53,9 +53,11 @@ describe('createHarnessEntryPointResolver', () => {
     ).toEqual(
       expect.objectContaining({
         type: 'sourceFile',
-        filePath: expect.stringContaining(
-          '@react-native-harness/runtime/entry-point',
-        ),
+        // In this workspace, `@react-native-harness/runtime/entry-point`
+        // resolves straight to the package's source file (no node_modules
+        // symlink in the path) rather than a string containing the package
+        // specifier, so assert on the resolved file itself.
+        filePath: expect.stringMatching(/entry-point(\.[cm]?[jt]sx?)?$/),
       }),
     );
   });

--- a/packages/bundler-metro/src/bundle-url.ts
+++ b/packages/bundler-metro/src/bundle-url.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+export type BundleClientProfile = 'expo' | 'bare';
+
+/**
+ * Metro only reuses a built dependency graph when the request's "graph key"
+ * (entryFile, platform, dev, minify, lazy, transform.* / resolver.* params,
+ * unstable_transformProfile) matches exactly. These param sets must mirror
+ * what each client actually requests, or the pre-warmed graph is wasted work.
+ */
+export const getBundleSearchParams = (
+  profile: BundleClientProfile,
+  platform: string
+): URLSearchParams => {
+  if (profile === 'expo') {
+    // Must stay byte-for-byte identical to the manifest launchAsset URL
+    // built by getExpoMiddleware/getExpoManifest for Expo (managed/dev-client)
+    // clients, or the pre-warmed graph won't match what the app requests.
+    return new URLSearchParams([
+      ['platform', platform],
+      ['dev', 'true'],
+      ['hot', 'false'],
+      ['lazy', 'true'],
+      ['transform.engine', 'hermes'],
+      ['transform.bytecode', '1'],
+      ['transform.routerRoot', 'app'],
+      ['transform.reactCompiler', 'true'],
+      ['unstable_transformProfile', 'hermes-stable'],
+    ]);
+  }
+
+  // Bare RN dev clients (RCTBundleURLProvider / DevServerHelper) request
+  // lazy=true in dev (lazy = enableDev), so the prewarm must match.
+  return new URLSearchParams([
+    ['platform', platform],
+    ['dev', 'true'],
+    ['minify', 'false'],
+    ['lazy', 'true'],
+  ]);
+};
+
+export const getBundleUrl = (options: {
+  port: number;
+  resolvedEntryPoint: string;
+  platform: string;
+  profile: BundleClientProfile;
+}): string => {
+  const { port, resolvedEntryPoint, platform, profile } = options;
+  const searchParams = getBundleSearchParams(profile, platform);
+
+  return `http://localhost:${port}/${resolvedEntryPoint}.bundle?${searchParams.toString()}`;
+};
+
+const EXPO_CONFIG_FILENAMES = [
+  'app.config.js',
+  'app.config.ts',
+  'app.config.mjs',
+  'app.config.cjs',
+];
+
+const hasExpoConfig = (projectRoot: string): boolean => {
+  if (
+    EXPO_CONFIG_FILENAMES.some((filename) =>
+      fs.existsSync(path.join(projectRoot, filename))
+    )
+  ) {
+    return true;
+  }
+
+  const appJsonPath = path.join(projectRoot, 'app.json');
+
+  if (!fs.existsSync(appJsonPath)) {
+    return false;
+  }
+
+  try {
+    const appJson = JSON.parse(fs.readFileSync(appJsonPath, 'utf8'));
+    return Boolean(appJson && typeof appJson === 'object' && 'expo' in appJson);
+  } catch {
+    return false;
+  }
+};
+
+const isExpoPackageResolvable = (projectRoot: string): boolean => {
+  try {
+    const require = createRequire(import.meta.url);
+    require.resolve('expo/package.json', { paths: [projectRoot] });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Detects whether a project should be treated as an Expo app for bundle
+ * URL purposes. Both an Expo config file (or an `app.json` with a top-level
+ * `expo` key) AND a resolvable `expo` package are required: a bare RN
+ * `app.json` is just `{name, displayName}`, and bare apps that merely have
+ * expo modules installed still lack the `expo` key -- so config presence
+ * disambiguates better than package resolution alone. Never throws; any
+ * read/parse failure is treated as 'bare'.
+ */
+export const detectBundleClientProfile = (
+  projectRoot: string
+): BundleClientProfile => {
+  try {
+    if (hasExpoConfig(projectRoot) && isExpoPackageResolvable(projectRoot)) {
+      return 'expo';
+    }
+  } catch {
+    return 'bare';
+  }
+
+  return 'bare';
+};

--- a/packages/bundler-metro/src/entry-point-utils.ts
+++ b/packages/bundler-metro/src/entry-point-utils.ts
@@ -1,7 +1,22 @@
 import { createRequire } from 'node:module';
+import fs from 'node:fs';
 import path from 'node:path';
 
 const require = createRequire(import.meta.url);
+
+// Node's CJS resolver returns a realpath'd absolute path (symlinks
+// resolved). On macOS, os.tmpdir() (and other paths) are commonly reached
+// through a symlink (e.g. /var -> /private/var), so projectRoot must be
+// realpath'd too before computing a relative path -- otherwise the result
+// is a bogus "../../../private/var/..." path instead of the intended
+// project-relative entry point.
+const realpathOrSelf = (input: string): string => {
+  try {
+    return fs.realpathSync(input);
+  } catch {
+    return input;
+  }
+};
 
 const CODE_EXTENSIONS = ['', '.ts', '.tsx', '.js', '.jsx'];
 
@@ -34,8 +49,9 @@ export const getResolvedEntryPointWithoutExtension = (
   projectRoot: string,
   entryPoint: string
 ) => {
+  const realProjectRoot = realpathOrSelf(projectRoot);
   const absolutePathToEntryPoint = resolveWithAbsolutePath(
-    projectRoot,
+    realProjectRoot,
     entryPoint
   );
 
@@ -45,5 +61,8 @@ export const getResolvedEntryPointWithoutExtension = (
     );
   }
 
-  return relativePathWithoutExtension(projectRoot, absolutePathToEntryPoint);
+  return relativePathWithoutExtension(
+    realProjectRoot,
+    absolutePathToEntryPoint
+  );
 };

--- a/packages/bundler-metro/src/factory.ts
+++ b/packages/bundler-metro/src/factory.ts
@@ -14,7 +14,9 @@ import {
 import { getExpoMiddleware } from './middlewares/expo-middleware.js';
 import { getBundleRequestObserverMiddleware } from './middlewares/bundle-request-middleware.js';
 import { getStatusMiddleware } from './middlewares/status-middleware.js';
-import { prewarmMetroBundle } from './prewarm.js';
+import { buildPrewarmUrl, prewarmMetroBundle } from './prewarm.js';
+import { detectBundleClientProfile } from './bundle-url.js';
+import { diffGraphRelevantParams } from './prewarm-guard.js';
 import { withRnHarness } from './withRnHarness.js';
 const metroLogger = logger.child('metro');
 
@@ -105,6 +107,12 @@ export const getMetroInstance = async (
   }
 
   const Metro = getMetroPackage(projectRoot);
+  const bundleClientProfile = detectBundleClientProfile(projectRoot);
+  metroLogger.debug(
+    'detected bundle client profile "%s" for %s',
+    bundleClientProfile,
+    projectRoot
+  );
 
   process.env.RN_HARNESS = 'true';
 
@@ -151,6 +159,29 @@ export const getMetroInstance = async (
   metroLogger.debug('Metro server is running');
 
   let prewarmResult: Promise<boolean> | null = null;
+  let prewarmRequestUrl: string | null = null;
+  let mismatchWarned = false;
+
+  const onBundleRequestObserved = (event: ReportableEvent) => {
+    if (event.type !== 'bundle_request_observed') {
+      return;
+    }
+
+    if (event.requestKind !== 'app' || !prewarmRequestUrl || mismatchWarned) {
+      return;
+    }
+
+    const diffs = diffGraphRelevantParams(prewarmRequestUrl, event.url);
+
+    if (diffs.length > 0) {
+      mismatchWarned = true;
+      metroLogger.warn(
+        'Pre-warmed Metro bundle graph key does not match the app-requested bundle graph key; the pre-warm may have built a graph the app cannot reuse. Mismatched: %s',
+        diffs.join(', ')
+      );
+    }
+  };
+  reporter.addListener(onBundleRequestObserved);
 
   return {
     events: reporter,
@@ -162,13 +193,16 @@ export const getMetroInstance = async (
       if (!prewarmResult) {
         prewarmResult = (async () => {
           try {
-            await prewarmMetroBundle({
+            const prewarmOptions = {
               projectRoot,
               entryPoint: harnessConfig.entryPoint,
               port: metroPort,
               platform,
-              dev: true,
-              minify: false,
+              profile: bundleClientProfile,
+            };
+            prewarmRequestUrl = buildPrewarmUrl(prewarmOptions);
+            await prewarmMetroBundle({
+              ...prewarmOptions,
               signal,
             });
             return true;
@@ -194,6 +228,7 @@ export const getMetroInstance = async (
     },
     dispose: () =>
       new Promise<void>((resolve) => {
+        reporter.removeListener(onBundleRequestObserved);
         server.close(() => resolve());
         server.closeAllConnections();
       }),

--- a/packages/bundler-metro/src/middlewares/expo-middleware.ts
+++ b/packages/bundler-metro/src/middlewares/expo-middleware.ts
@@ -3,6 +3,7 @@ import type { NextFunction } from 'connect';
 import type { Config as HarnessConfig } from '@react-native-harness/config';
 import crypto from 'node:crypto';
 import { getResolvedEntryPointWithoutExtension } from '../entry-point-utils.js';
+import { getBundleUrl } from '../bundle-url.js';
 
 export const getExpoMiddleware =
   (projectRoot: string, harnessConfig: HarnessConfig) =>
@@ -25,7 +26,12 @@ export const getExpoMiddleware =
       launchAsset: {
         key: 'bundle',
         contentType: 'application/javascript',
-        url: `http://localhost:${harnessConfig.metroPort}/${resolvedEntryPoint}.bundle?platform=${platform}&dev=true&hot=false&lazy=true&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&transform.reactCompiler=true&unstable_transformProfile=hermes-stable`,
+        url: getBundleUrl({
+          port: harnessConfig.metroPort,
+          resolvedEntryPoint,
+          platform,
+          profile: 'expo',
+        }),
       },
       assets: [],
       metadata: {},

--- a/packages/bundler-metro/src/prewarm-guard.ts
+++ b/packages/bundler-metro/src/prewarm-guard.ts
@@ -1,0 +1,80 @@
+const PARAM_DEFAULTS: Record<string, string> = {
+  dev: 'true',
+  minify: 'false',
+  lazy: 'false',
+  shallow: 'false',
+  unstable_transformProfile: 'default',
+};
+
+const isTransformOrResolverParam = (key: string): boolean =>
+  key.startsWith('transform.') || key.startsWith('resolver.');
+
+/**
+ * Compares two bundle request URLs on Metro's graph-key dimensions only
+ * (entryFile/pathname, platform, dev, minify, lazy, shallow,
+ * unstable_transformProfile, and every transform.* / resolver.* param).
+ * Everything else (app, hot, runModule, modulesOnly, inlineSourceMap,
+ * excludeSource, sourcePaths, sourceMapUrl, ...) is serializer-only and
+ * ignored. Returns a list of human-readable descriptions of the mismatched
+ * keys, or an empty array when the requests would resolve to the same
+ * Metro dependency graph. Never throws -- malformed URLs are treated as
+ * "no diff" so this can never crash the caller.
+ */
+export const diffGraphRelevantParams = (
+  prewarmUrl: string,
+  appUrl: string
+): string[] => {
+  try {
+    const prewarm = new URL(prewarmUrl, 'http://localhost');
+    const app = new URL(appUrl, 'http://localhost');
+    const diffs: string[] = [];
+
+    const prewarmPathname = decodeURIComponent(prewarm.pathname);
+    const appPathname = decodeURIComponent(app.pathname);
+
+    if (prewarmPathname !== appPathname) {
+      diffs.push(`pathname (prewarm=${prewarmPathname}, app=${appPathname})`);
+    }
+
+    const compareParam = (key: string, defaultValue = '') => {
+      const prewarmValue = prewarm.searchParams.get(key) ?? defaultValue;
+      const appValue = app.searchParams.get(key) ?? defaultValue;
+
+      if (prewarmValue !== appValue) {
+        diffs.push(`${key} (prewarm=${prewarmValue}, app=${appValue})`);
+      }
+    };
+
+    compareParam('platform');
+    compareParam('dev', PARAM_DEFAULTS.dev);
+    compareParam('minify', PARAM_DEFAULTS.minify);
+    compareParam('lazy', PARAM_DEFAULTS.lazy);
+    compareParam('shallow', PARAM_DEFAULTS.shallow);
+    compareParam(
+      'unstable_transformProfile',
+      PARAM_DEFAULTS.unstable_transformProfile
+    );
+
+    const transformResolverKeys = new Set<string>();
+
+    for (const key of prewarm.searchParams.keys()) {
+      if (isTransformOrResolverParam(key)) {
+        transformResolverKeys.add(key);
+      }
+    }
+
+    for (const key of app.searchParams.keys()) {
+      if (isTransformOrResolverParam(key)) {
+        transformResolverKeys.add(key);
+      }
+    }
+
+    for (const key of transformResolverKeys) {
+      compareParam(key);
+    }
+
+    return diffs;
+  } catch {
+    return [];
+  }
+};

--- a/packages/bundler-metro/src/prewarm.ts
+++ b/packages/bundler-metro/src/prewarm.ts
@@ -1,31 +1,33 @@
 import { getResolvedEntryPointWithoutExtension } from './entry-point-utils.js';
 import { HARNESS_REQUEST_KIND_HEADER } from './request-kind.js';
+import { getBundleUrl, type BundleClientProfile } from './bundle-url.js';
 
 type PrewarmOptions = {
   projectRoot: string;
   entryPoint: string;
   port: number;
   platform: string;
-  dev: boolean;
-  minify: boolean;
+  profile: BundleClientProfile;
   signal: AbortSignal;
+};
+
+export const buildPrewarmUrl = (
+  options: Omit<PrewarmOptions, 'signal'>
+): string => {
+  const { projectRoot, entryPoint, port, platform, profile } = options;
+  const resolvedEntryPoint = getResolvedEntryPointWithoutExtension(
+    projectRoot,
+    entryPoint
+  );
+
+  return getBundleUrl({ port, resolvedEntryPoint, platform, profile });
 };
 
 export const prewarmMetroBundle = async (
   options: PrewarmOptions
 ): Promise<void> => {
-  const { projectRoot, entryPoint, port, platform, dev, minify, signal } =
-    options;
-  const resolvedEntryPoint = getResolvedEntryPointWithoutExtension(
-    projectRoot,
-    entryPoint
-  );
-  const searchParams = new URLSearchParams({
-    platform,
-    dev: String(dev),
-    minify: String(minify),
-  });
-  const url = `http://localhost:${port}/${resolvedEntryPoint}.bundle?${searchParams.toString()}`;
+  const { signal } = options;
+  const url = buildPrewarmUrl(options);
 
   const response = await fetch(url, {
     signal,

--- a/packages/bundler-metro/vite.config.ts
+++ b/packages/bundler-metro/vite.config.ts
@@ -1,0 +1,18 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/bundler-metro',
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));


### PR DESCRIPTION
## What is this?

The harness pre-warms Metro by fetching the app's bundle before the app launches, so the JS graph is already built by the time the app connects. Metro only reuses that built graph when a later request's "graph key" (entry file, platform, `dev`, `minify`, `lazy`, every `transform.*`/`resolver.*` param, `unstable_transformProfile`) matches exactly.

It didn't, on either platform we support:

- **Expo**: the manifest middleware (`expo-middleware.ts`) hardcodes a launch-asset URL with `lazy=true&transform.engine=hermes&transform.bytecode=1&transform.routerRoot=app&transform.reactCompiler=true&unstable_transformProfile=hermes-stable`. The prewarm request sent none of that — just `platform`, `dev=true`, `minify=false`. Five graph-key mismatches, and since `transform.*` also changes the transform cache key per module, the Expo prewarm was building a graph the app essentially never reused.
- **Bare RN**: dev clients (`RCTBundleURLProvider` / `DevServerHelper`) request `lazy=true` in dev builds. The prewarm didn't send `lazy` at all, so it mismatched on that one param (still degraded, not useless, since the transform cache is shared here).

This PR makes the prewarm request byte-identical to what each client type actually requests, and adds a guard that loudly reports if they ever drift apart again.

## How does it work?

- **`packages/bundler-metro/src/bundle-url.ts`** is the new single source of truth for bundle request URLs. `getBundleUrl({ port, resolvedEntryPoint, platform, profile })` builds the URL for a `BundleClientProfile` of `'expo' | 'bare'`. The `expo` param set is reproduced byte-for-byte from what `expo-middleware.ts` used to hardcode; the `bare` set adds `lazy=true` to the previous `platform`/`dev`/`minify` params.
- `expo-middleware.ts` now calls `getBundleUrl(..., profile: 'expo')` instead of hand-building the query string — a behavioral no-op, verified by a test that runs the real middleware and diffs its manifest URL against `getBundleUrl`'s output.
- `detectBundleClientProfile(projectRoot)` (same module) decides which profile a project gets, once, when the Metro instance is created:

  | app.json / app.config.* | `expo` package resolves | Result |
  |---|---|---|
  | has `app.config.{js,ts,mjs,cjs}`, or `app.json` with a top-level `expo` key | yes | `expo` |
  | same as above | no | `bare` |
  | plain `app.json` (`{name, displayName}`) or none | yes or no | `bare` |
  | unparseable `app.json` | — | `bare` (fails safe, never throws) |

  Both signals are required because a bare RN `app.json` is just `{name, displayName}`, and a bare app with Expo modules installed still won't have the `expo` key — config presence is what actually distinguishes them.
- `prewarm.ts` now builds its request URL through the same `getBundleUrl`, driven by the detected profile instead of ad-hoc `dev`/`minify` options. `factory.ts` detects the profile once per Metro instance and threads it into `prewarm()`.
- A verify-on-connect guard in `factory.ts` records the prewarm's URL and, on the first app-originated `bundle_request_observed` event, runs the new `diffGraphRelevantParams(prewarmUrl, appUrl)` helper (in `prewarm-guard.ts`) to compare pathname, `platform`, `dev`, `minify`, `lazy`, `shallow`, `unstable_transformProfile`, and every `transform.*`/`resolver.*` param — applying Metro's defaults so `?dev=true` and an omitted `dev` count as equal, and ignoring serializer-only params like `app`, `hot`, `runModule`. Any real mismatch logs one `metroLogger.warn` naming the differing keys, at most once per session; the listener is cleaned up in `dispose()`.

## Why is this useful?

- The Expo prewarm now actually warms the graph the app requests, instead of silently building a throwaway one — this was the biggest win, since `transform.*` mismatches meant the transform cache didn't help either.
- Bare RN prewarm now matches `lazy=true`, closing the remaining gap there too.
- Both clients go through one shared builder, so the manifest URL and the prewarm URL can't drift apart by construction going forward.
- The mismatch guard turns a previously silent, hard-to-notice perf regression into a single logged warning if it ever happens again (e.g. Metro adds a new graph-key dimension, or a client starts sending different params).
- Along the way, this also fixes a real (if narrow) bug in `entry-point-utils.ts`: `projectRoot` wasn't realpath'd before computing the entry point's relative path, which produced a bogus `../../../private/var/...` result whenever the project root was reached through a symlink (e.g. macOS `/var` → `/private/var`, common for temp/dev directories). This was invisible because `packages/bundler-metro` had no wired-up Vite test target (`vite.config.ts` — added here); its existing test suite had never actually run in CI.
