### PR TITLE
Pin Android emulator to 2 vCPUs and warn when acceleration is unavailable

### DIFF
--- a/.nx/version-plans/derive-device-core-budget.md
+++ b/.nx/version-plans/derive-device-core-budget.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Android Harness runs now use more of the CPU available on larger machines, making local emulator tests faster without changing behavior on small CI runners.

--- a/actions/shared/index.cjs
+++ b/actions/shared/index.cjs
@@ -633,8 +633,8 @@ function getErrorMap() {
 
 // ../../node_modules/zod/dist/esm/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path8, errorMaps, issueData } = params;
-  const fullPath = [...path8, ...issueData.path || []];
+  const { data, path: path9, errorMaps, issueData } = params;
+  const fullPath = [...path9, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -750,11 +750,11 @@ var errorUtil;
 
 // ../../node_modules/zod/dist/esm/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path8, key) {
+  constructor(parent, value, path9, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path8;
+    this._path = path9;
     this._key = key;
   }
   get path() {
@@ -4357,6 +4357,26 @@ var DEFAULT_ARTIFACT_ROOT = import_node_path5.default.join(process.cwd(), ".harn
 var import_node_fs5 = __toESM(require("fs"), 1);
 var import_node_path6 = __toESM(require("path"), 1);
 
+// ../tools/dist/diagnostics.js
+var noop = () => void 0;
+var noopSpan = {
+  end: noop,
+  fail: noop
+};
+var createNoopDiagnostics = () => {
+  const diagnostics = {
+    enabled: false,
+    start: () => noopSpan,
+    measure: async (_label, fn) => fn(),
+    mark: noop,
+    record: noop,
+    child: () => diagnostics,
+    flush: () => []
+  };
+  return diagnostics;
+};
+var noopDiagnostics = createNoopDiagnostics();
+
 // ../plugins/dist/utils.js
 var isHookTree = (value) => {
   if (value == null || typeof value !== "object" || Array.isArray(value)) {
@@ -4421,6 +4441,7 @@ var ConfigSchema = external_exports.object({
   platformReadyTimeout: external_exports.number().min(1e3, "Platform ready timeout must be at least 1 second").default(3e5),
   bundleStartTimeout: external_exports.number().min(1e3, "Bundle start timeout must be at least 1 second").default(6e4),
   maxAppRestarts: external_exports.number().min(0, "Max app restarts must be at least 0").default(2),
+  eagerPrewarm: external_exports.boolean().optional().default(true).describe("Start building the Metro bundle while the platform (emulator, simulator, or browser) is still booting, so the first bundle is ready sooner. Disable to defer the first bundle build until app startup."),
   resetEnvironmentBetweenTestFiles: external_exports.boolean().optional().default(true),
   unstable__skipAlreadyIncludedModules: external_exports.boolean().optional().default(false),
   unstable__enableMetroCache: external_exports.boolean().optional().default(false),
@@ -4437,6 +4458,7 @@ var ConfigSchema = external_exports.object({
     }).optional().describe("Native code coverage configuration.")
   }).optional(),
   forwardClientLogs: external_exports.boolean().optional().default(false).describe("Enable forwarding of console.log, console.warn, console.error, and other console method calls from the React Native app during the active test run. When enabled, app console output is attached to the active test result's console output."),
+  diagnostics: external_exports.boolean().optional().default(false).describe("Enable diagnostics tracing for the harness session. Records spans for session setup, Metro bundling, bridge/client events, and per-file test runs, then writes a Chrome Trace Event JSON file and prints a summary after each run. Can also be enabled via the RN_HARNESS_DIAGNOSTICS environment variable."),
   // Deprecated property - used for migration detection
   include: external_exports.array(external_exports.string()).optional()
 }).refine((config) => {
@@ -4543,8 +4565,8 @@ var importUp = async (dir, name) => {
       } catch (error) {
         if (error instanceof ZodError) {
           const validationErrors = error.errors.map((err) => {
-            const path8 = err.path.length > 0 ? ` at "${err.path.join(".")}"` : "";
-            return `${err.message}${path8}`;
+            const path9 = err.path.length > 0 ? ` at "${err.path.join(".")}"` : "";
+            return `${err.message}${path9}`;
           });
           throw new ConfigValidationError(filePathWithExt, validationErrors);
         }
@@ -4566,10 +4588,32 @@ var getConfig = async (dir) => {
   };
 };
 
+// ../platform-android/dist/avd-config.js
+var import_promises3 = require("fs/promises");
+
+// ../platform-android/dist/environment.js
+var import_node_fs7 = require("fs");
+var import_promises = require("fs/promises");
+var import_node_os = __toESM(require("os"), 1);
+var import_node_path8 = __toESM(require("path"), 1);
+var import_promises2 = require("stream/promises");
+var import_node_https = __toESM(require("https"), 1);
+var androidEnvironmentLogger = logger.child("android-environment");
+
+// ../platform-android/dist/emulator-startup.js
+var emulatorStartupLogger = logger.child("android-emulator-startup");
+var EMULATOR_CPU_CORES = 2;
+
+// ../platform-android/dist/adb.js
+var import_node_child_process = require("child_process");
+var import_promises4 = require("fs/promises");
+var EMULATOR_OUTPUT_BUFFER_LIMIT = 16 * 1024;
+var androidAdbLogger = logger.child("android-adb");
+
 // src/shared/index.ts
-var import_node_path8 = __toESM(require("path"));
-var import_node_fs7 = __toESM(require("fs"));
-var getHostAndroidSystemImageArch = () => {
+var import_node_path9 = __toESM(require("path"));
+var import_node_fs8 = __toESM(require("fs"));
+var getHostAndroidSystemImageArch2 = () => {
   switch (process.arch) {
     case "arm64":
       return "arm64-v8a";
@@ -4580,14 +4624,14 @@ var getHostAndroidSystemImageArch = () => {
       return "x86_64";
   }
 };
-var resolveAvdCachingEnabled = ({
+var resolveAvdCachingEnabled2 = ({
   snapshotEnabled
 }) => {
   const override = process.env.HARNESS_AVD_CACHING;
   const requestedValue = override == null ? snapshotEnabled : override.toLowerCase() === "true";
   return requestedValue === true;
 };
-var getNormalizedAvdCacheConfig = ({
+var getNormalizedAvdCacheConfig2 = ({
   emulator,
   hostArch
 }) => {
@@ -4601,14 +4645,18 @@ var getNormalizedAvdCacheConfig = ({
     arch: hostArch,
     profile: avd.profile.trim().toLowerCase(),
     diskSize: avd.diskSize.trim().toLowerCase(),
-    heapSize: avd.heapSize.trim().toLowerCase()
+    heapSize: avd.heapSize.trim().toLowerCase(),
+    // Roll the AVD cache key whenever the baked-in vCPU count changes, so a
+    // cached AVD built before this constant existed regenerates once instead
+    // of failing the compatibility check on every run.
+    cpuCores: EMULATOR_CPU_CORES
   };
 };
 var getResolvedRunner = (runner) => {
   if (runner.platformId !== "android" || runner.config.device.type !== "emulator") {
     return runner;
   }
-  const avdCachingEnabled = resolveAvdCachingEnabled({
+  const avdCachingEnabled = resolveAvdCachingEnabled2({
     snapshotEnabled: runner.config.device.avd?.snapshot?.enabled
   });
   return {
@@ -4622,9 +4670,9 @@ var getResolvedRunner = (runner) => {
     },
     action: {
       avdCachingEnabled,
-      avdCacheConfig: getNormalizedAvdCacheConfig({
+      avdCacheConfig: getNormalizedAvdCacheConfig2({
         emulator: runner.config.device,
-        hostArch: getHostAndroidSystemImageArch()
+        hostArch: getHostAndroidSystemImageArch2()
       })
     }
   };
@@ -4636,7 +4684,7 @@ var run = async () => {
     if (!runnerInput) {
       throw new Error("Runner input is required");
     }
-    const projectRoot = projectRootInput ? import_node_path8.default.resolve(projectRootInput) : process.cwd();
+    const projectRoot = projectRootInput ? import_node_path9.default.resolve(projectRootInput) : process.cwd();
     console.info(`Loading React Native Harness config from: ${projectRoot}`);
     const { config, projectRoot: resolvedProjectRoot } = await getConfig(
       projectRoot
@@ -4650,13 +4698,13 @@ var run = async () => {
       throw new Error("GITHUB_OUTPUT environment variable is not set");
     }
     const resolvedRunner = getResolvedRunner(runner);
-    const relativeProjectRoot = import_node_path8.default.relative(process.cwd(), resolvedProjectRoot) || ".";
+    const relativeProjectRoot = import_node_path9.default.relative(process.cwd(), resolvedProjectRoot) || ".";
     const output = `config=${JSON.stringify(
       resolvedRunner
     )}
 projectRoot=${relativeProjectRoot}
 `;
-    import_node_fs7.default.appendFileSync(githubOutput, output);
+    import_node_fs8.default.appendFileSync(githubOutput, output);
   } catch (error) {
     if (error instanceof Error) {
       console.error(error.message);

--- a/actions/shared/index.cjs
+++ b/actions/shared/index.cjs
@@ -4377,6 +4377,13 @@ var createNoopDiagnostics = () => {
 };
 var noopDiagnostics = createNoopDiagnostics();
 
+// ../tools/dist/device-core-budget.js
+var MIN_DEVICE_CORE_BUDGET = 2;
+var MAX_DEVICE_CORE_BUDGET = 4;
+var getDeviceCoreBudget = (hostParallelism) => {
+  return Math.min(Math.max(Math.floor(hostParallelism / 2), MIN_DEVICE_CORE_BUDGET), MAX_DEVICE_CORE_BUDGET);
+};
+
 // ../plugins/dist/utils.js
 var isHookTree = (value) => {
   if (value == null || typeof value !== "object" || Array.isArray(value)) {
@@ -4591,6 +4598,9 @@ var getConfig = async (dir) => {
 // ../platform-android/dist/avd-config.js
 var import_promises3 = require("fs/promises");
 
+// ../platform-android/dist/emulator-startup.js
+var import_node_os2 = __toESM(require("os"), 1);
+
 // ../platform-android/dist/environment.js
 var import_node_fs7 = require("fs");
 var import_promises = require("fs/promises");
@@ -4613,7 +4623,9 @@ var getHostAndroidSystemImageArch = (architecture = process.arch) => {
 
 // ../platform-android/dist/emulator-startup.js
 var emulatorStartupLogger = logger.child("android-emulator-startup");
-var EMULATOR_CPU_CORES = 2;
+var getEmulatorCpuCores = () => {
+  return getDeviceCoreBudget(import_node_os2.default.availableParallelism());
+};
 
 // ../platform-android/dist/adb.js
 var import_node_child_process = require("child_process");
@@ -4649,7 +4661,7 @@ var getNormalizedAvdCacheConfig2 = ({
     // Roll the AVD cache key whenever the baked-in vCPU count changes, so a
     // cached AVD built before this constant existed regenerates once instead
     // of failing the compatibility check on every run.
-    cpuCores: EMULATOR_CPU_CORES
+    cpuCores: getEmulatorCpuCores()
   };
 };
 var getResolvedRunner = (runner) => {

--- a/actions/shared/index.cjs
+++ b/actions/shared/index.cjs
@@ -4599,6 +4599,17 @@ var import_node_path8 = __toESM(require("path"), 1);
 var import_promises2 = require("stream/promises");
 var import_node_https = __toESM(require("https"), 1);
 var androidEnvironmentLogger = logger.child("android-environment");
+var getHostAndroidSystemImageArch = (architecture = process.arch) => {
+  switch (architecture) {
+    case "arm64":
+      return "arm64-v8a";
+    case "arm":
+      return "armeabi-v7a";
+    case "x64":
+    default:
+      return "x86_64";
+  }
+};
 
 // ../platform-android/dist/emulator-startup.js
 var emulatorStartupLogger = logger.child("android-emulator-startup");
@@ -4613,17 +4624,6 @@ var androidAdbLogger = logger.child("android-adb");
 // src/shared/index.ts
 var import_node_path9 = __toESM(require("path"));
 var import_node_fs8 = __toESM(require("fs"));
-var getHostAndroidSystemImageArch2 = () => {
-  switch (process.arch) {
-    case "arm64":
-      return "arm64-v8a";
-    case "arm":
-      return "armeabi-v7a";
-    case "x64":
-    default:
-      return "x86_64";
-  }
-};
 var resolveAvdCachingEnabled2 = ({
   snapshotEnabled
 }) => {
@@ -4672,7 +4672,7 @@ var getResolvedRunner = (runner) => {
       avdCachingEnabled,
       avdCacheConfig: getNormalizedAvdCacheConfig2({
         emulator: runner.config.device,
-        hostArch: getHostAndroidSystemImageArch2()
+        hostArch: getHostAndroidSystemImageArch()
       })
     }
   };

--- a/packages/github-action/package.json
+++ b/packages/github-action/package.json
@@ -11,7 +11,8 @@
     "build": "tsup"
   },
   "dependencies": {
-    "@react-native-harness/config": "workspace:*"
+    "@react-native-harness/config": "workspace:*",
+    "@react-native-harness/platform-android": "workspace:*"
   },
   "devDependencies": {
     "tsup": "^8.5.1"

--- a/packages/github-action/src/shared/index.ts
+++ b/packages/github-action/src/shared/index.ts
@@ -1,22 +1,10 @@
 import { getConfig } from '@react-native-harness/config';
-import { EMULATOR_CPU_CORES } from '@react-native-harness/platform-android';
+import {
+  EMULATOR_CPU_CORES,
+  getHostAndroidSystemImageArch,
+} from '@react-native-harness/platform-android';
 import path from 'node:path';
 import fs from 'node:fs';
-
-const getHostAndroidSystemImageArch = ():
-  | 'x86_64'
-  | 'arm64-v8a'
-  | 'armeabi-v7a' => {
-  switch (process.arch) {
-    case 'arm64':
-      return 'arm64-v8a';
-    case 'arm':
-      return 'armeabi-v7a';
-    case 'x64':
-    default:
-      return 'x86_64';
-  }
-};
 
 const resolveAvdCachingEnabled = ({
   snapshotEnabled,

--- a/packages/github-action/src/shared/index.ts
+++ b/packages/github-action/src/shared/index.ts
@@ -1,6 +1,6 @@
 import { getConfig } from '@react-native-harness/config';
 import {
-  EMULATOR_CPU_CORES,
+  getEmulatorCpuCores,
   getHostAndroidSystemImageArch,
 } from '@react-native-harness/platform-android';
 import path from 'node:path';
@@ -49,7 +49,7 @@ const getNormalizedAvdCacheConfig = ({
     // Roll the AVD cache key whenever the baked-in vCPU count changes, so a
     // cached AVD built before this constant existed regenerates once instead
     // of failing the compatibility check on every run.
-    cpuCores: EMULATOR_CPU_CORES,
+    cpuCores: getEmulatorCpuCores(),
   };
 };
 

--- a/packages/github-action/src/shared/index.ts
+++ b/packages/github-action/src/shared/index.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@react-native-harness/config';
+import { EMULATOR_CPU_CORES } from '@react-native-harness/platform-android';
 import path from 'node:path';
 import fs from 'node:fs';
 
@@ -57,6 +58,10 @@ const getNormalizedAvdCacheConfig = ({
     profile: avd.profile.trim().toLowerCase(),
     diskSize: avd.diskSize.trim().toLowerCase(),
     heapSize: avd.heapSize.trim().toLowerCase(),
+    // Roll the AVD cache key whenever the baked-in vCPU count changes, so a
+    // cached AVD built before this constant existed regenerates once instead
+    // of failing the compatibility check on every run.
+    cpuCores: EMULATOR_CPU_CORES,
   };
 };
 

--- a/packages/github-action/tsconfig.json
+++ b/packages/github-action/tsconfig.json
@@ -7,6 +7,9 @@
       "path": "../config"
     },
     {
+      "path": "../platform-android"
+    },
+    {
       "path": "./tsconfig.lib.json"
     }
   ]

--- a/packages/github-action/tsconfig.lib.json
+++ b/packages/github-action/tsconfig.lib.json
@@ -13,6 +13,9 @@
   "references": [
     {
       "path": "../config/tsconfig.lib.json"
+    },
+    {
+      "path": "../platform-android/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/platform-android/src/__tests__/avd-config.test.ts
+++ b/packages/platform-android/src/__tests__/avd-config.test.ts
@@ -6,6 +6,7 @@ import {
   resolveAvdCachingEnabled,
 } from '../avd-config.js';
 import { AndroidPlatformConfigSchema } from '../config.js';
+import { EMULATOR_CPU_CORES } from '../emulator-startup.js';
 
 describe('AVD config helpers', () => {
   it('parses snapshot config from Android schema', () => {
@@ -73,7 +74,10 @@ abi.type=x86_64
 hw.device.name=pixel_8
 disk.dataPartition.size=1G
 vm.heapSize=512M
+hw.cpu.ncore=${EMULATOR_CPU_CORES}
 `);
+
+    expect(avdConfig.hwCpuNcore).toBe(String(EMULATOR_CPU_CORES));
 
     expect(
       isAvdCompatible({
@@ -93,6 +97,67 @@ vm.heapSize=512M
     ).toEqual({ compatible: true });
   });
 
+  it('rejects AVDs missing hw.cpu.ncore', () => {
+    const avdConfig = parseAvdConfig(`
+image.sysdir.1=system-images/android-35/default/x86_64/
+abi.type=x86_64
+hw.device.name=pixel_8
+disk.dataPartition.size=1G
+vm.heapSize=512M
+`);
+
+    expect(
+      isAvdCompatible({
+        emulator: {
+          type: 'emulator',
+          name: 'Pixel_8_API_35',
+          avd: {
+            apiLevel: 35,
+            profile: 'pixel_8',
+            diskSize: '1G',
+            heapSize: '512M',
+          },
+        },
+        avdConfig,
+        hostArch: 'x86_64',
+      })
+    ).toMatchObject({
+      compatible: false,
+      reason: `CPU core count mismatch: expected ${EMULATOR_CPU_CORES}, got missing.`,
+    });
+  });
+
+  it('rejects AVDs with a different hw.cpu.ncore', () => {
+    const avdConfig = parseAvdConfig(`
+image.sysdir.1=system-images/android-35/default/x86_64/
+abi.type=x86_64
+hw.device.name=pixel_8
+disk.dataPartition.size=1G
+vm.heapSize=512M
+hw.cpu.ncore=4
+`);
+
+    expect(
+      isAvdCompatible({
+        emulator: {
+          type: 'emulator',
+          name: 'Pixel_8_API_35',
+          avd: {
+            apiLevel: 35,
+            profile: 'pixel_8',
+            diskSize: '1G',
+            heapSize: '512M',
+          },
+        },
+        avdConfig,
+        hostArch: 'x86_64',
+      })
+    ).toMatchObject({
+      compatible: false,
+      reason: `CPU core count mismatch: expected ${EMULATOR_CPU_CORES}, got 4.`,
+    });
+  });
+
   it('accepts disk partition sizes rewritten to bytes', () => {
     const avdConfig = parseAvdConfig(`
 image.sysdir.1=system-images/android-35/default/x86_64/
@@ -100,6 +165,7 @@ abi.type=x86_64
 hw.device.name=pixel_8
 disk.dataPartition.size=6442450944
 vm.heapSize=512M
+hw.cpu.ncore=${EMULATOR_CPU_CORES}
 `);
 
     expect(

--- a/packages/platform-android/src/__tests__/avd-config.test.ts
+++ b/packages/platform-android/src/__tests__/avd-config.test.ts
@@ -6,7 +6,9 @@ import {
   resolveAvdCachingEnabled,
 } from '../avd-config.js';
 import { AndroidPlatformConfigSchema } from '../config.js';
-import { EMULATOR_CPU_CORES } from '../emulator-startup.js';
+import { getEmulatorCpuCores } from '../emulator-startup.js';
+
+const emulatorCpuCores = getEmulatorCpuCores();
 
 describe('AVD config helpers', () => {
   it('parses snapshot config from Android schema', () => {
@@ -74,10 +76,10 @@ abi.type=x86_64
 hw.device.name=pixel_8
 disk.dataPartition.size=1G
 vm.heapSize=512M
-hw.cpu.ncore=${EMULATOR_CPU_CORES}
+hw.cpu.ncore=${emulatorCpuCores}
 `);
 
-    expect(avdConfig.hwCpuNcore).toBe(String(EMULATOR_CPU_CORES));
+    expect(avdConfig.hwCpuNcore).toBe(String(emulatorCpuCores));
 
     expect(
       isAvdCompatible({
@@ -123,7 +125,7 @@ vm.heapSize=512M
       })
     ).toMatchObject({
       compatible: false,
-      reason: `CPU core count mismatch: expected ${EMULATOR_CPU_CORES}, got missing.`,
+      reason: `CPU core count mismatch: expected ${emulatorCpuCores}, got missing.`,
     });
   });
 
@@ -134,7 +136,7 @@ abi.type=x86_64
 hw.device.name=pixel_8
 disk.dataPartition.size=1G
 vm.heapSize=512M
-hw.cpu.ncore=4
+hw.cpu.ncore=${emulatorCpuCores === 4 ? 3 : 4}
 `);
 
     expect(
@@ -154,7 +156,9 @@ hw.cpu.ncore=4
       })
     ).toMatchObject({
       compatible: false,
-      reason: `CPU core count mismatch: expected ${EMULATOR_CPU_CORES}, got 4.`,
+      reason: `CPU core count mismatch: expected ${emulatorCpuCores}, got ${
+        emulatorCpuCores === 4 ? 3 : 4
+      }.`,
     });
   });
 
@@ -165,7 +169,7 @@ abi.type=x86_64
 hw.device.name=pixel_8
 disk.dataPartition.size=6442450944
 vm.heapSize=512M
-hw.cpu.ncore=${EMULATOR_CPU_CORES}
+hw.cpu.ncore=${emulatorCpuCores}
 `);
 
     expect(

--- a/packages/platform-android/src/__tests__/emulator-startup.test.ts
+++ b/packages/platform-android/src/__tests__/emulator-startup.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getEmulatorStartupArgs } from '../emulator-startup.js';
+import {
+  getEmulatorStartupArgs,
+  isAccelerationUsable,
+} from '../emulator-startup.js';
 
 describe('emulator startup modes', () => {
   it('builds default boot args', () => {
@@ -8,6 +11,7 @@ describe('emulator startup modes', () => {
         '@Pixel_8_API_35',
         '-no-snapshot-load',
         '-no-snapshot-save',
+        '-no-metrics',
       ])
     );
     expect(getEmulatorStartupArgs('Pixel_8_API_35', 'default-boot')).not.toEqual(
@@ -18,7 +22,13 @@ describe('emulator startup modes', () => {
   it('builds clean snapshot generation args', () => {
     expect(
       getEmulatorStartupArgs('Pixel_8_API_35', 'clean-snapshot-generation')
-    ).toEqual(expect.arrayContaining(['@Pixel_8_API_35', '-no-snapshot-load']));
+    ).toEqual(
+      expect.arrayContaining([
+        '@Pixel_8_API_35',
+        '-no-snapshot-load',
+        '-no-metrics',
+      ])
+    );
     expect(
       getEmulatorStartupArgs('Pixel_8_API_35', 'clean-snapshot-generation')
     ).not.toContain('-no-snapshot-save');
@@ -26,10 +36,36 @@ describe('emulator startup modes', () => {
 
   it('builds snapshot reuse args', () => {
     expect(getEmulatorStartupArgs('Pixel_8_API_35', 'snapshot-reuse')).toEqual(
-      expect.arrayContaining(['@Pixel_8_API_35', '-no-snapshot-save'])
+      expect.arrayContaining([
+        '@Pixel_8_API_35',
+        '-no-snapshot-save',
+        '-no-metrics',
+      ])
     );
     expect(
       getEmulatorStartupArgs('Pixel_8_API_35', 'snapshot-reuse')
     ).not.toContain('-no-snapshot-load');
+  });
+});
+
+describe('isAccelerationUsable', () => {
+  it('returns true when the emulator reports acceleration is usable', () => {
+    expect(
+      isAccelerationUsable(
+        'accel:\n0\nKVM (version 12) is installed and usable.\naccel\n'
+      )
+    ).toBe(true);
+  });
+
+  it('returns false when acceleration is disabled', () => {
+    expect(
+      isAccelerationUsable(
+        'accel:\n0\nKVM is not installed on this machine.\naccel\n'
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for empty output', () => {
+    expect(isAccelerationUsable('')).toBe(false);
   });
 });

--- a/packages/platform-android/src/__tests__/emulator-startup.test.ts
+++ b/packages/platform-android/src/__tests__/emulator-startup.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getEmulatorCpuCores,
   getEmulatorStartupArgs,
   isAccelerationUsable,
 } from '../emulator-startup.js';
+import { getDeviceCoreBudget } from '@react-native-harness/tools';
+import os from 'node:os';
+
+describe('getEmulatorCpuCores', () => {
+  it('uses the shared device-core budget for the current host', () => {
+    expect(getEmulatorCpuCores()).toBe(
+      getDeviceCoreBudget(os.availableParallelism())
+    );
+  });
+});
 
 describe('emulator startup modes', () => {
   it('builds default boot args', () => {
@@ -14,9 +25,9 @@ describe('emulator startup modes', () => {
         '-no-metrics',
       ])
     );
-    expect(getEmulatorStartupArgs('Pixel_8_API_35', 'default-boot')).not.toEqual(
-      expect.arrayContaining(['-camera-back', 'none'])
-    );
+    expect(
+      getEmulatorStartupArgs('Pixel_8_API_35', 'default-boot')
+    ).not.toEqual(expect.arrayContaining(['-camera-back', 'none']));
   });
 
   it('builds clean snapshot generation args', () => {

--- a/packages/platform-android/src/__tests__/instance.test.ts
+++ b/packages/platform-android/src/__tests__/instance.test.ts
@@ -13,7 +13,7 @@ import * as avdConfig from '../avd-config.js';
 import * as sharedPrefs from '../shared-prefs.js';
 import { HarnessAppPathError, HarnessEmulatorConfigError } from '../errors.js';
 import * as emulatorStartup from '../emulator-startup.js';
-const { EMULATOR_CPU_CORES } = emulatorStartup;
+const { getEmulatorCpuCores } = emulatorStartup;
 
 const createLogcatProcess = (lines: string[] = []): Subprocess => {
   const process = {
@@ -48,11 +48,11 @@ describe('Android platform instance', () => {
     vi.useRealTimers();
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorAvailable',
+      'ensureAndroidEmulatorAvailable'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(
       emulatorStartup,
-      'warnIfEmulatorAccelerationUnavailable',
+      'warnIfEmulatorAccelerationUnavailable'
     ).mockResolvedValue(undefined);
   });
 
@@ -60,7 +60,7 @@ describe('Android platform instance', () => {
     const ensureAndroidEmulatorEnvironment = vi
       .spyOn(
         await import('../environment.js'),
-        'ensureAndroidEmulatorEnvironment',
+        'ensureAndroidEmulatorEnvironment'
       )
       .mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue(['emulator-5554']);
@@ -70,14 +70,12 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     vi.spyOn(sharedPrefs, 'clearHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     vi.spyOn(adb, 'stopApp').mockResolvedValue(undefined);
     const stopEmulator = vi.spyOn(adb, 'stopEmulator').mockResolvedValue();
@@ -99,7 +97,7 @@ describe('Android platform instance', () => {
         activityName: '.MainActivity',
       },
       harnessConfig,
-      init,
+      init
     );
 
     await instance.dispose();
@@ -111,7 +109,7 @@ describe('Android platform instance', () => {
   it('creates and boots an emulator when missing and shuts it down on dispose', async () => {
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([]);
     vi.spyOn(adb, 'hasAvd').mockResolvedValue(false);
@@ -124,14 +122,12 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     vi.spyOn(sharedPrefs, 'clearHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     vi.spyOn(adb, 'stopApp').mockResolvedValue(undefined);
     const stopEmulator = vi.spyOn(adb, 'stopEmulator').mockResolvedValue();
@@ -153,7 +149,7 @@ describe('Android platform instance', () => {
         activityName: '.MainActivity',
       },
       harnessConfig,
-      init,
+      init
     );
 
     expect(createAvd).toHaveBeenCalledWith({
@@ -174,7 +170,7 @@ describe('Android platform instance', () => {
     const ensureAndroidEmulatorEnvironment = vi
       .spyOn(
         await import('../environment.js'),
-        'ensureAndroidEmulatorEnvironment',
+        'ensureAndroidEmulatorEnvironment'
       )
       .mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([]);
@@ -188,11 +184,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
 
     await expect(
@@ -213,8 +207,8 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).resolves.toBeDefined();
 
     expect(ensureAndroidEmulatorEnvironment).toHaveBeenCalledWith(35);
@@ -226,11 +220,11 @@ describe('Android platform instance', () => {
     vi.stubEnv('HARNESS_AVD_CACHING', 'true');
     vi.spyOn(
       await import('../environment.js'),
-      'getHostAndroidSystemImageArch',
+      'getHostAndroidSystemImageArch'
     ).mockReturnValue('arm64-v8a');
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([]);
     vi.spyOn(adb, 'hasAvd').mockResolvedValue(true);
@@ -240,7 +234,7 @@ describe('Android platform instance', () => {
       hwDeviceName: 'pixel_8',
       diskDataPartitionSize: '1G',
       vmHeapSize: '1G',
-      hwCpuNcore: String(EMULATOR_CPU_CORES),
+      hwCpuNcore: String(getEmulatorCpuCores()),
     });
     vi.spyOn(adb, 'startEmulator').mockResolvedValue(undefined);
     vi.spyOn(adb, 'waitForBoot').mockResolvedValue('emulator-5554');
@@ -248,11 +242,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
 
     await expect(
@@ -274,14 +266,14 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).resolves.toBeDefined();
 
     expect(adb.startEmulator).toHaveBeenCalledTimes(1);
     expect(adb.startEmulator).toHaveBeenCalledWith(
       'Pixel_8_API_35',
-      'snapshot-reuse',
+      'snapshot-reuse'
     );
   });
 
@@ -289,7 +281,7 @@ describe('Android platform instance', () => {
     vi.stubEnv('HARNESS_AVD_CACHING', 'true');
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([]);
     vi.spyOn(adb, 'hasAvd').mockResolvedValue(true);
@@ -312,11 +304,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
 
     await expect(
@@ -338,8 +328,8 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).resolves.toBeDefined();
 
     expect(deleteAvd).toHaveBeenCalledWith('Pixel_8_API_35');
@@ -347,17 +337,17 @@ describe('Android platform instance', () => {
     expect(stopEmulator).toHaveBeenCalledWith('emulator-5554');
     expect(waitForEmulatorDisconnect).toHaveBeenCalledWith(
       'emulator-5554',
-      init.signal,
+      init.signal
     );
     expect(adb.startEmulator).toHaveBeenNthCalledWith(
       1,
       'Pixel_8_API_35',
-      'clean-snapshot-generation',
+      'clean-snapshot-generation'
     );
     expect(adb.startEmulator).toHaveBeenNthCalledWith(
       2,
       'Pixel_8_API_35',
-      'snapshot-reuse',
+      'snapshot-reuse'
     );
   });
 
@@ -365,7 +355,7 @@ describe('Android platform instance', () => {
     vi.stubEnv('HARNESS_AVD_CACHING', 'true');
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue([]);
     vi.spyOn(adb, 'hasAvd').mockResolvedValue(false);
@@ -382,11 +372,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
 
     await expect(
@@ -408,24 +396,24 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).resolves.toBeDefined();
 
     expect(startEmulator).toHaveBeenNthCalledWith(
       1,
       'Pixel_8_API_35',
-      'clean-snapshot-generation',
+      'clean-snapshot-generation'
     );
     expect(stopEmulator).toHaveBeenCalledWith('emulator-5554');
     expect(waitForEmulatorDisconnect).toHaveBeenCalledWith(
       'emulator-5554',
-      init.signal,
+      init.signal
     );
     expect(startEmulator).toHaveBeenNthCalledWith(
       2,
       'Pixel_8_API_35',
-      'snapshot-reuse',
+      'snapshot-reuse'
     );
   });
 
@@ -453,8 +441,8 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).rejects.toBeInstanceOf(HarnessAppPathError);
   });
 
@@ -483,8 +471,8 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).rejects.toBeInstanceOf(HarnessAppPathError);
   });
 
@@ -503,8 +491,8 @@ describe('Android platform instance', () => {
           activityName: '.MainActivity',
         },
         harnessConfig,
-        init,
-      ),
+        init
+      )
     ).rejects.toBeInstanceOf(HarnessEmulatorConfigError);
   });
 
@@ -512,7 +500,7 @@ describe('Android platform instance', () => {
     vi.useFakeTimers();
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue(['emulator-5554']);
     vi.spyOn(adb, 'getEmulatorName').mockResolvedValue('Pixel_8_API_35');
@@ -521,11 +509,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     const stopApp = vi.spyOn(adb, 'stopApp').mockResolvedValue(undefined);
     const startApp = vi.spyOn(adb, 'startApp').mockResolvedValue(undefined);
@@ -551,7 +537,7 @@ describe('Android platform instance', () => {
         activityName: '.MainActivity',
       },
       harnessConfigWithoutNativeCrashDetection,
-      init,
+      init
     );
 
     const listener = vi.fn();
@@ -570,7 +556,7 @@ describe('Android platform instance', () => {
       '01-01 00:00:00.000',
     ]);
     expect(startLogcat.mock.invocationCallOrder[0]).toBeLessThan(
-      startApp.mock.invocationCallOrder[0],
+      startApp.mock.invocationCallOrder[0]
     );
     await expect(appSession.getState()).resolves.toEqual({
       status: 'running',
@@ -587,7 +573,7 @@ describe('Android platform instance', () => {
     vi.useFakeTimers();
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue(['emulator-5554']);
     vi.spyOn(adb, 'getEmulatorName').mockResolvedValue('Pixel_8_API_35');
@@ -596,11 +582,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     vi.spyOn(adb, 'stopApp').mockResolvedValue(undefined);
     vi.spyOn(adb, 'startApp').mockResolvedValue(undefined);
@@ -610,7 +594,7 @@ describe('Android platform instance', () => {
         '--------- beginning of crash',
         'Process: com.harnessplayground, PID: 7777',
         'FATAL EXCEPTION: main',
-      ]),
+      ])
     );
 
     const instance = await getAndroidEmulatorPlatformInstance(
@@ -630,7 +614,7 @@ describe('Android platform instance', () => {
         activityName: '.MainActivity',
       },
       harnessConfig,
-      init,
+      init
     );
 
     const listener = vi.fn();
@@ -665,11 +649,9 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'reversePort').mockResolvedValue(undefined);
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
-    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue(
-      '01-01 00:00:00.000',
-    );
+    vi.spyOn(adb, 'getLogcatTimestamp').mockResolvedValue('01-01 00:00:00.000');
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     vi.spyOn(adb, 'stopApp').mockResolvedValue(undefined);
     vi.spyOn(adb, 'startApp').mockResolvedValue(undefined);
@@ -689,7 +671,7 @@ describe('Android platform instance', () => {
         bundleId: 'com.harnessplayground',
         activityName: '.MainActivity',
       },
-      harnessConfigWithoutNativeCrashDetection,
+      harnessConfigWithoutNativeCrashDetection
     );
 
     const listener = vi.fn();
@@ -719,7 +701,7 @@ describe('Android platform instance', () => {
   it('grants permissions when permissions are enabled for emulator', async () => {
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue(['emulator-5554']);
     vi.spyOn(adb, 'getEmulatorName').mockResolvedValue('Pixel_8_API_35');
@@ -729,7 +711,7 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     const grantPermissions = vi
       .spyOn(adb, 'grantPermissions')
@@ -757,19 +739,19 @@ describe('Android platform instance', () => {
         activityName: '.MainActivity',
       },
       harnessConfigWithPermissions,
-      init,
+      init
     );
 
     expect(grantPermissions).toHaveBeenCalledWith(
       'emulator-5554',
-      'com.harnessplayground',
+      'com.harnessplayground'
     );
   });
 
   it('does not grant permissions when permissions are disabled for emulator', async () => {
     vi.spyOn(
       await import('../environment.js'),
-      'ensureAndroidEmulatorEnvironment',
+      'ensureAndroidEmulatorEnvironment'
     ).mockResolvedValue('/tmp/android-sdk');
     vi.spyOn(adb, 'getDeviceIds').mockResolvedValue(['emulator-5554']);
     vi.spyOn(adb, 'getEmulatorName').mockResolvedValue('Pixel_8_API_35');
@@ -779,7 +761,7 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     const grantPermissions = vi
       .spyOn(adb, 'grantPermissions')
@@ -802,7 +784,7 @@ describe('Android platform instance', () => {
         activityName: '.MainActivity',
       },
       harnessConfig,
-      init,
+      init
     );
 
     expect(grantPermissions).not.toHaveBeenCalled();
@@ -819,7 +801,7 @@ describe('Android platform instance', () => {
     vi.spyOn(adb, 'setHideErrorDialogs').mockResolvedValue(undefined);
     vi.spyOn(adb, 'getAppUid').mockResolvedValue(10234);
     vi.spyOn(sharedPrefs, 'applyHarnessDebugHttpHost').mockResolvedValue(
-      undefined,
+      undefined
     );
     const grantPermissions = vi
       .spyOn(adb, 'grantPermissions')
@@ -841,12 +823,12 @@ describe('Android platform instance', () => {
         bundleId: 'com.harnessplayground',
         activityName: '.MainActivity',
       },
-      harnessConfigWithPermissions,
+      harnessConfigWithPermissions
     );
 
     expect(grantPermissions).toHaveBeenCalledWith(
       '012345',
-      'com.harnessplayground',
+      'com.harnessplayground'
     );
   });
 });

--- a/packages/platform-android/src/__tests__/instance.test.ts
+++ b/packages/platform-android/src/__tests__/instance.test.ts
@@ -12,6 +12,8 @@ import * as adb from '../adb.js';
 import * as avdConfig from '../avd-config.js';
 import * as sharedPrefs from '../shared-prefs.js';
 import { HarnessAppPathError, HarnessEmulatorConfigError } from '../errors.js';
+import * as emulatorStartup from '../emulator-startup.js';
+const { EMULATOR_CPU_CORES } = emulatorStartup;
 
 const createLogcatProcess = (lines: string[] = []): Subprocess => {
   const process = {
@@ -48,6 +50,10 @@ describe('Android platform instance', () => {
       await import('../environment.js'),
       'ensureAndroidEmulatorAvailable',
     ).mockResolvedValue('/tmp/android-sdk');
+    vi.spyOn(
+      emulatorStartup,
+      'warnIfEmulatorAccelerationUnavailable',
+    ).mockResolvedValue(undefined);
   });
 
   it('reuses a running emulator and does not shut it down on dispose', async () => {
@@ -234,6 +240,7 @@ describe('Android platform instance', () => {
       hwDeviceName: 'pixel_8',
       diskDataPartitionSize: '1G',
       vmHeapSize: '1G',
+      hwCpuNcore: String(EMULATOR_CPU_CORES),
     });
     vi.spyOn(adb, 'startEmulator').mockResolvedValue(undefined);
     vi.spyOn(adb, 'waitForBoot').mockResolvedValue('emulator-5554');

--- a/packages/platform-android/src/adb.ts
+++ b/packages/platform-android/src/adb.ts
@@ -25,7 +25,7 @@ import {
   getRequiredAndroidSdkPackages,
 } from './environment.js';
 import {
-  EMULATOR_CPU_CORES,
+  getEmulatorCpuCores,
   getEmulatorStartupArgs,
   type EmulatorBootMode,
 } from './emulator-startup.js';
@@ -51,14 +51,14 @@ const waitForAbort = (signal: AbortSignal): Promise<never> => {
       () => {
         reject(signal.reason);
       },
-      { once: true },
+      { once: true }
     );
   });
 };
 
 const waitWithSignal = async (
   ms: number,
-  signal: AbortSignal,
+  signal: AbortSignal
 ): Promise<void> => {
   if (signal.aborted) {
     throw signal.reason;
@@ -74,7 +74,7 @@ const androidAdbLogger = logger.child('android-adb');
 export const emulatorProcess = {
   startDetachedProcess: (
     file: string,
-    args: readonly string[],
+    args: readonly string[]
   ): ChildProcessByStdio<null, Readable, Readable> =>
     nodeSpawn(file, args, {
       detached: true,
@@ -85,7 +85,7 @@ export const emulatorProcess = {
 const appendBoundedOutput = (
   output: string,
   chunk: string,
-  limit: number = EMULATOR_OUTPUT_BUFFER_LIMIT,
+  limit: number = EMULATOR_OUTPUT_BUFFER_LIMIT
 ): string => {
   const nextOutput = output + chunk;
 
@@ -166,7 +166,7 @@ export const getRequiredEmulatorPackages = (apiLevel: number): string[] => {
 };
 
 export const verifyAndroidEmulatorSdk = async (
-  apiLevel: number,
+  apiLevel: number
 ): Promise<void> => {
   await ensureAndroidSdkPackages(getRequiredEmulatorPackages(apiLevel));
 };
@@ -193,7 +193,7 @@ const ensureAvdProfileAvailable = async (profile: string): Promise<void> => {
       : 'None reported by avdmanager.';
 
   throw new Error(
-    `Android AVD profile "${profile}" is not available on this machine. Available profiles: ${availableProfilesList}`,
+    `Android AVD profile "${profile}" is not available on this machine. Available profiles: ${availableProfilesList}`
   );
 };
 
@@ -202,7 +202,7 @@ const ensureAvdConfigExists = async (name: string): Promise<string> => {
 
   if ((await readAvdConfig(name)) == null) {
     throw new Error(
-      `Android AVD "${name}" was created, but config.ini was not found at ${configPath}.`,
+      `Android AVD "${name}" was created, but config.ini was not found at ${configPath}.`
     );
   }
 
@@ -236,7 +236,7 @@ const ensureAvdIniExists = async ({
 export const getStartAppArgs = (
   bundleId: string,
   activityName: string,
-  options?: AndroidAppLaunchOptions,
+  options?: AndroidAppLaunchOptions
 ): string[] => {
   const args = [
     'shell',
@@ -265,7 +265,7 @@ export const getStartAppArgs = (
 
     if (!Number.isSafeInteger(value)) {
       throw new Error(
-        `Android app launch option "${key}" must be a safe integer.`,
+        `Android app launch option "${key}" must be a safe integer.`
       );
     }
 
@@ -277,7 +277,7 @@ export const getStartAppArgs = (
 
 export const isAppInstalled = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<boolean> => {
   const { stdout } = await spawn(getAdbBinaryPath(), [
     '-s',
@@ -294,7 +294,7 @@ export const isAppInstalled = async (
 export const reversePort = async (
   adbId: string,
   port: number,
-  hostPort: number = port,
+  hostPort: number = port
 ): Promise<void> => {
   await spawn(getAdbBinaryPath(), [
     '-s',
@@ -307,7 +307,7 @@ export const reversePort = async (
 
 export const stopApp = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<void> => {
   await spawn(getAdbBinaryPath(), [
     '-s',
@@ -323,7 +323,7 @@ export const startApp = async (
   adbId: string,
   bundleId: string,
   activityName: string,
-  options?: AndroidAppLaunchOptions,
+  options?: AndroidAppLaunchOptions
 ): Promise<void> => {
   await spawn(getAdbBinaryPath(), [
     '-s',
@@ -342,7 +342,7 @@ export const getDeviceIds = async (): Promise<string[]> => {
 };
 
 export const getEmulatorName = async (
-  adbId: string,
+  adbId: string
 ): Promise<string | null> => {
   const { stdout } = await spawn(getAdbBinaryPath(), [
     '-s',
@@ -356,7 +356,7 @@ export const getEmulatorName = async (
 
 export const getShellProperty = async (
   adbId: string,
-  property: string,
+  property: string
 ): Promise<string | null> => {
   const { stdout } = await spawn(getAdbBinaryPath(), [
     '-s',
@@ -378,7 +378,7 @@ export type DeviceInfo = {
 };
 
 export const getDeviceInfo = async (
-  adbId: string,
+  adbId: string
 ): Promise<DeviceInfo | null> => {
   const manufacturer = await getShellProperty(adbId, 'ro.product.manufacturer');
   const model = await getShellProperty(adbId, 'ro.product.model');
@@ -387,7 +387,7 @@ export const getDeviceInfo = async (
 
 const getRequestedPermissions = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<string[]> => {
   const { stdout } = await spawn(getAdbBinaryPath(), [
     '-s',
@@ -477,14 +477,14 @@ export const stopEmulator = async (adbId: string): Promise<void> => {
 
 export const installApp = async (
   adbId: string,
-  appPath: string,
+  appPath: string
 ): Promise<void> => {
   await spawn(getAdbBinaryPath(), ['-s', adbId, 'install', '-r', appPath]);
 };
 
 export const uninstallApp = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<void> => {
   await spawn(getAdbBinaryPath(), ['-s', adbId, 'uninstall', bundleId]);
 };
@@ -503,14 +503,16 @@ export const createAvd = async ({
 }: CreateAvdOptions): Promise<void> => {
   const systemImagePackage = getAndroidSystemImagePackage(
     apiLevel,
-    getHostAndroidSystemImageArch(),
+    getHostAndroidSystemImageArch()
   );
 
   await verifyAndroidEmulatorSdk(apiLevel);
   await ensureAvdProfileAvailable(profile);
   await spawn('bash', [
     '-lc',
-    `printf 'no\n' | "${getAvdManagerBinaryPath()}" create avd --force --name "${name}" --package "${systemImagePackage}" --device "${profile}" -p "${getAvdDirectory(name)}"`,
+    `printf 'no\n' | "${getAvdManagerBinaryPath()}" create avd --force --name "${name}" --package "${systemImagePackage}" --device "${profile}" -p "${getAvdDirectory(
+      name
+    )}"`,
   ]);
   await ensureAvdIniExists({ name, apiLevel });
   const configPath = await ensureAvdConfigExists(name);
@@ -521,7 +523,7 @@ export const createAvd = async ({
   // boots.
   await spawn('bash', [
     '-lc',
-    `printf '%s\n%s\n%s\n' 'disk.dataPartition.size=${diskSize}' 'vm.heapSize=${heapSize}' 'hw.cpu.ncore=${EMULATOR_CPU_CORES}' >> "${configPath}"`,
+    `printf '%s\n%s\n%s\n' 'disk.dataPartition.size=${diskSize}' 'vm.heapSize=${heapSize}' 'hw.cpu.ncore=${getEmulatorCpuCores()}' >> "${configPath}"`,
   ]);
 };
 
@@ -533,7 +535,7 @@ export const deleteAvd = async (name: string): Promise<void> => {
     {
       force: true,
       recursive: true,
-    },
+    }
   );
   await rm(
     `${
@@ -541,18 +543,18 @@ export const deleteAvd = async (name: string): Promise<void> => {
     }/${name}.ini`,
     {
       force: true,
-    },
+    }
   );
 };
 
 export const startEmulator = async (
   name: string,
-  mode: EmulatorBootMode = 'default-boot',
+  mode: EmulatorBootMode = 'default-boot'
 ): Promise<void> => {
   const emulatorBinaryPath = await ensureEmulatorInstalled();
   const childProcess = emulatorProcess.startDetachedProcess(
     emulatorBinaryPath,
-    getEmulatorStartupArgs(name, mode),
+    getEmulatorStartupArgs(name, mode)
   );
 
   let stdout = '';
@@ -588,7 +590,7 @@ export const startEmulator = async (
           stdout,
           stderr,
           error,
-        }),
+        })
       );
     });
 
@@ -600,7 +602,7 @@ export const startEmulator = async (
           stderr,
           exitCode,
           signal,
-        }),
+        })
       );
     });
   });
@@ -616,7 +618,7 @@ export const startEmulator = async (
     });
 
   const observationTimeout = wait(EMULATOR_STARTUP_OBSERVATION_TIMEOUT_MS).then(
-    () => 'timeout' as const,
+    () => 'timeout' as const
   );
 
   try {
@@ -632,7 +634,7 @@ export const startEmulator = async (
 
 export const waitForEmulator = async (
   name: string,
-  signal: AbortSignal,
+  signal: AbortSignal
 ): Promise<string> => {
   while (!signal.aborted) {
     const adbIds = await getDeviceIds();
@@ -657,7 +659,7 @@ export const waitForEmulator = async (
 
 export const waitForEmulatorDisconnect = async (
   adbId: string,
-  signal: AbortSignal,
+  signal: AbortSignal
 ): Promise<void> => {
   while (!signal.aborted) {
     const adbIds = await getDeviceIds();
@@ -674,7 +676,7 @@ export const waitForEmulatorDisconnect = async (
 
 export const waitForBoot = async (
   name: string,
-  signal: AbortSignal,
+  signal: AbortSignal
 ): Promise<string> => {
   while (!signal.aborted) {
     const adbIds = await getDeviceIds();
@@ -703,14 +705,14 @@ export const waitForBoot = async (
 
 export const isAppRunning = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<boolean> => {
   return (await getAppPid(adbId, bundleId)) != null;
 };
 
 export const getAppPid = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<number | null> => {
   try {
     const { stdout } = await spawn(getAdbBinaryPath(), [
@@ -737,7 +739,7 @@ export const getAppPid = async (
 
 export const getAppUid = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<number> => {
   const { stdout } = await spawn(getAdbBinaryPath(), [
     '-s',
@@ -762,7 +764,7 @@ export const getAppUid = async (
 
 export const setHideErrorDialogs = async (
   adbId: string,
-  hide: boolean,
+  hide: boolean
 ): Promise<void> => {
   await spawn(getAdbBinaryPath(), [
     '-s',
@@ -790,7 +792,7 @@ export const getLogcatTimestamp = async (adbId: string): Promise<string> => {
 
 export const startLogcat = (
   adbId: string,
-  args: readonly string[],
+  args: readonly string[]
 ): Subprocess =>
   spawn(getAdbBinaryPath(), ['-s', adbId, ...args], {
     stdout: 'pipe',
@@ -804,7 +806,7 @@ export const DROPBOX_CRASH_TAGS = [
 
 export const getDropboxPrint = async (
   adbId: string,
-  tags: readonly string[] = DROPBOX_CRASH_TAGS,
+  tags: readonly string[] = DROPBOX_CRASH_TAGS
 ): Promise<string> => {
   // Android treats multiple args after --print as one search string, so each
   // tag must be queried separately and merged on the host.
@@ -821,7 +823,7 @@ export const getDropboxPrint = async (
       ]);
 
       return stdout;
-    }),
+    })
   );
 
   return outputs.join('\n');
@@ -829,7 +831,7 @@ export const getDropboxPrint = async (
 
 export const getActivityExitInfo = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<string> => {
   const { stdout } = await spawn(getAdbBinaryPath(), [
     '-s',
@@ -897,7 +899,7 @@ export const getConnectedDevices = async (): Promise<AdbDevice[]> => {
 
 export const grantPermissions = async (
   adbId: string,
-  bundleId: string,
+  bundleId: string
 ): Promise<void> => {
   androidAdbLogger.debug('grantPermissions:start %o', {
     adbId,
@@ -914,7 +916,7 @@ export const grantPermissions = async (
     getDangerousPermissions(adbId),
   ]);
   const permissions = requestedPermissions.filter((permission) =>
-    dangerousPermissions.has(permission),
+    dangerousPermissions.has(permission)
   );
 
   androidAdbLogger.debug('grantPermissions:resolved %o', {
@@ -950,7 +952,7 @@ export const grantPermissions = async (
     });
 
     await Promise.all(
-      grantCommands.map((args) => spawn(getAdbBinaryPath(), args as string[])),
+      grantCommands.map((args) => spawn(getAdbBinaryPath(), args as string[]))
     );
 
     androidAdbLogger.debug('grantPermissions:success %o', {

--- a/packages/platform-android/src/adb.ts
+++ b/packages/platform-android/src/adb.ts
@@ -25,6 +25,7 @@ import {
   getRequiredAndroidSdkPackages,
 } from './environment.js';
 import {
+  EMULATOR_CPU_CORES,
   getEmulatorStartupArgs,
   type EmulatorBootMode,
 } from './emulator-startup.js';
@@ -513,9 +514,14 @@ export const createAvd = async ({
   ]);
   await ensureAvdIniExists({ name, apiLevel });
   const configPath = await ensureAvdConfigExists(name);
+  // hw.cpu.ncore is baked into config.ini (rather than passed as a `-cores`
+  // boot flag) so it's part of the AVD's persisted hardware profile: boot
+  // snapshots require an identical hardware config to load, so the vCPU
+  // count must be fixed at AVD-creation time and stay consistent across
+  // boots.
   await spawn('bash', [
     '-lc',
-    `printf '%s\n%s\n' 'disk.dataPartition.size=${diskSize}' 'vm.heapSize=${heapSize}' >> "${configPath}"`,
+    `printf '%s\n%s\n%s\n' 'disk.dataPartition.size=${diskSize}' 'vm.heapSize=${heapSize}' 'hw.cpu.ncore=${EMULATOR_CPU_CORES}' >> "${configPath}"`,
   ]);
 };
 

--- a/packages/platform-android/src/avd-config.ts
+++ b/packages/platform-android/src/avd-config.ts
@@ -1,7 +1,7 @@
 import { access, readFile } from 'node:fs/promises';
 import type { AndroidSystemImageArch } from './environment.js';
 import type { AndroidEmulator, AndroidEmulatorAVDConfig } from './config.js';
-import { EMULATOR_CPU_CORES } from './emulator-startup.js';
+import { getEmulatorCpuCores } from './emulator-startup.js';
 
 export type AvdConfig = {
   imageSysdir1?: string;
@@ -242,11 +242,11 @@ export const isAvdCompatible = ({
 
   if (
     normalizeConfigValue(avdConfig.hwCpuNcore ?? '') !==
-    normalizeConfigValue(String(EMULATOR_CPU_CORES))
+    normalizeConfigValue(String(getEmulatorCpuCores()))
   ) {
     return {
       compatible: false,
-      reason: `CPU core count mismatch: expected ${EMULATOR_CPU_CORES}, got ${
+      reason: `CPU core count mismatch: expected ${getEmulatorCpuCores()}, got ${
         avdConfig.hwCpuNcore ?? 'missing'
       }.`,
     };

--- a/packages/platform-android/src/avd-config.ts
+++ b/packages/platform-android/src/avd-config.ts
@@ -1,6 +1,7 @@
 import { access, readFile } from 'node:fs/promises';
 import type { AndroidSystemImageArch } from './environment.js';
 import type { AndroidEmulator, AndroidEmulatorAVDConfig } from './config.js';
+import { EMULATOR_CPU_CORES } from './emulator-startup.js';
 
 export type AvdConfig = {
   imageSysdir1?: string;
@@ -8,6 +9,7 @@ export type AvdConfig = {
   hwDeviceName?: string;
   diskDataPartitionSize?: string;
   vmHeapSize?: string;
+  hwCpuNcore?: string;
 };
 
 export type AvdCompatibilityResult =
@@ -123,6 +125,9 @@ export const parseAvdConfig = (contents: string): AvdConfig => {
       case 'vm.heapSize':
         config.vmHeapSize = value;
         break;
+      case 'hw.cpu.ncore':
+        config.hwCpuNcore = value;
+        break;
       default:
         break;
     }
@@ -232,6 +237,18 @@ export const isAvdCompatible = ({
       reason: `Heap size mismatch: expected ${
         requestedAvdConfig.heapSize
       }, got ${avdConfig.vmHeapSize ?? 'missing'}.`,
+    };
+  }
+
+  if (
+    normalizeConfigValue(avdConfig.hwCpuNcore ?? '') !==
+    normalizeConfigValue(String(EMULATOR_CPU_CORES))
+  ) {
+    return {
+      compatible: false,
+      reason: `CPU core count mismatch: expected ${EMULATOR_CPU_CORES}, got ${
+        avdConfig.hwCpuNcore ?? 'missing'
+      }.`,
     };
   }
 

--- a/packages/platform-android/src/emulator-startup.ts
+++ b/packages/platform-android/src/emulator-startup.ts
@@ -1,4 +1,10 @@
-import { logger, spawn, SubprocessError } from '@react-native-harness/tools';
+import {
+  getDeviceCoreBudget,
+  logger,
+  spawn,
+  SubprocessError,
+} from '@react-native-harness/tools';
+import os from 'node:os';
 import { getEmulatorBinaryPath } from './environment.js';
 
 const emulatorStartupLogger = logger.child('android-emulator-startup');
@@ -9,20 +15,15 @@ export type EmulatorBootMode =
   | 'snapshot-reuse';
 
 /**
- * Number of vCPUs baked into the AVD's `hw.cpu.ncore` at creation time.
+ * Returns the vCPU count baked into an AVD for this runner.
  *
- * GitHub-hosted CI runners only have 2-4 cores available (ubuntu-latest: 4
- * public / 2 private vCPUs; macos-latest arm64: 3-4 cores), so the emulator
- * guest must not claim the whole host. 2 vCPUs is enough for headless
- * instrumented tests and leaves the remaining host cores free for Metro's
- * transform workers and the Node test session.
- *
- * This is a fixed constant rather than something derived from the host CPU
- * count so AVDs (and their boot snapshots) stay byte-identical/portable
- * across runners of different sizes - loading a saved snapshot requires an
- * identical hardware configuration.
+ * AVD snapshots require an identical hardware configuration to load, so all
+ * AVD creation, compatibility, and cache-key callers must use this value on
+ * the same host.
  */
-export const EMULATOR_CPU_CORES = 2;
+export const getEmulatorCpuCores = (): number => {
+  return getDeviceCoreBudget(os.availableParallelism());
+};
 
 const COMMON_EMULATOR_ARGS = [
   '-no-window',
@@ -64,35 +65,36 @@ export const isAccelerationUsable = (accelCheckOutput: string): boolean => {
  * block emulator startup - any error running it is swallowed and only
  * debug-logged.
  */
-export const warnIfEmulatorAccelerationUnavailable = async (): Promise<void> => {
-  let combinedOutput: string;
+export const warnIfEmulatorAccelerationUnavailable =
+  async (): Promise<void> => {
+    let combinedOutput: string;
 
-  try {
-    const emulatorBinaryPath = getEmulatorBinaryPath();
-    const { stdout, stderr } = await spawn(emulatorBinaryPath, [
-      '-accel-check',
-    ]);
-    combinedOutput = `${stdout}\n${stderr}`;
-  } catch (error) {
-    if (error instanceof SubprocessError) {
-      // The check itself ran but exited non-zero - this is how
-      // `-accel-check` reports that acceleration is unavailable, so treat
-      // its output as a normal (non-fatal) result rather than swallowing it.
-      combinedOutput = `${error.stdout}\n${error.stderr}`;
-    } else {
-      // Failed to even run the check (e.g. binary missing). This must never
-      // fail or block emulator startup.
-      emulatorStartupLogger.debug(
-        'Failed to run "emulator -accel-check": %o',
-        error
-      );
-      return;
+    try {
+      const emulatorBinaryPath = getEmulatorBinaryPath();
+      const { stdout, stderr } = await spawn(emulatorBinaryPath, [
+        '-accel-check',
+      ]);
+      combinedOutput = `${stdout}\n${stderr}`;
+    } catch (error) {
+      if (error instanceof SubprocessError) {
+        // The check itself ran but exited non-zero - this is how
+        // `-accel-check` reports that acceleration is unavailable, so treat
+        // its output as a normal (non-fatal) result rather than swallowing it.
+        combinedOutput = `${error.stdout}\n${error.stderr}`;
+      } else {
+        // Failed to even run the check (e.g. binary missing). This must never
+        // fail or block emulator startup.
+        emulatorStartupLogger.debug(
+          'Failed to run "emulator -accel-check": %o',
+          error
+        );
+        return;
+      }
     }
-  }
 
-  if (!isAccelerationUsable(combinedOutput)) {
-    logger.warn(
-      'Hardware acceleration (KVM/HVF) appears unavailable for the Android emulator. It will fall back to very slow software emulation.'
-    );
-  }
-};
+    if (!isAccelerationUsable(combinedOutput)) {
+      logger.warn(
+        'Hardware acceleration (KVM/HVF) appears unavailable for the Android emulator. It will fall back to very slow software emulation.'
+      );
+    }
+  };

--- a/packages/platform-android/src/emulator-startup.ts
+++ b/packages/platform-android/src/emulator-startup.ts
@@ -1,7 +1,28 @@
+import { logger, spawn, SubprocessError } from '@react-native-harness/tools';
+import { getEmulatorBinaryPath } from './environment.js';
+
+const emulatorStartupLogger = logger.child('android-emulator-startup');
+
 export type EmulatorBootMode =
   | 'default-boot'
   | 'clean-snapshot-generation'
   | 'snapshot-reuse';
+
+/**
+ * Number of vCPUs baked into the AVD's `hw.cpu.ncore` at creation time.
+ *
+ * GitHub-hosted CI runners only have 2-4 cores available (ubuntu-latest: 4
+ * public / 2 private vCPUs; macos-latest arm64: 3-4 cores), so the emulator
+ * guest must not claim the whole host. 2 vCPUs is enough for headless
+ * instrumented tests and leaves the remaining host cores free for Metro's
+ * transform workers and the Node test session.
+ *
+ * This is a fixed constant rather than something derived from the host CPU
+ * count so AVDs (and their boot snapshots) stay byte-identical/portable
+ * across runners of different sizes - loading a saved snapshot requires an
+ * identical hardware configuration.
+ */
+export const EMULATOR_CPU_CORES = 2;
 
 const COMMON_EMULATOR_ARGS = [
   '-no-window',
@@ -9,6 +30,7 @@ const COMMON_EMULATOR_ARGS = [
   'swiftshader_indirect',
   '-noaudio',
   '-no-boot-anim',
+  '-no-metrics',
 ] as const;
 
 export const getEmulatorStartupArgs = (
@@ -23,4 +45,54 @@ export const getEmulatorStartupArgs = (
       : ['-no-snapshot-load', '-no-snapshot-save'];
 
   return [`@${name}`, ...modeArgs, ...COMMON_EMULATOR_ARGS];
+};
+
+/**
+ * Parses the output of `emulator -accel-check` to determine whether
+ * hardware acceleration (KVM on Linux, HVF on macOS) is usable. The
+ * emulator prints a message containing "is installed and usable" when
+ * acceleration is available.
+ */
+export const isAccelerationUsable = (accelCheckOutput: string): boolean => {
+  return accelCheckOutput.includes('is installed and usable');
+};
+
+/**
+ * Runs `emulator -accel-check` and logs a non-fatal warning when hardware
+ * acceleration (KVM/HVF) appears unavailable, in which case the emulator
+ * falls back to very slow software emulation. This check must never fail or
+ * block emulator startup - any error running it is swallowed and only
+ * debug-logged.
+ */
+export const warnIfEmulatorAccelerationUnavailable = async (): Promise<void> => {
+  let combinedOutput: string;
+
+  try {
+    const emulatorBinaryPath = getEmulatorBinaryPath();
+    const { stdout, stderr } = await spawn(emulatorBinaryPath, [
+      '-accel-check',
+    ]);
+    combinedOutput = `${stdout}\n${stderr}`;
+  } catch (error) {
+    if (error instanceof SubprocessError) {
+      // The check itself ran but exited non-zero - this is how
+      // `-accel-check` reports that acceleration is unavailable, so treat
+      // its output as a normal (non-fatal) result rather than swallowing it.
+      combinedOutput = `${error.stdout}\n${error.stderr}`;
+    } else {
+      // Failed to even run the check (e.g. binary missing). This must never
+      // fail or block emulator startup.
+      emulatorStartupLogger.debug(
+        'Failed to run "emulator -accel-check": %o',
+        error
+      );
+      return;
+    }
+  }
+
+  if (!isAccelerationUsable(combinedOutput)) {
+    logger.warn(
+      'Hardware acceleration (KVM/HVF) appears unavailable for the Android emulator. It will fall back to very slow software emulation.'
+    );
+  }
 };

--- a/packages/platform-android/src/index.ts
+++ b/packages/platform-android/src/index.ts
@@ -9,5 +9,6 @@ export {
   resolveAvdCachingEnabled,
 } from './avd-config.js';
 export { getHostAndroidSystemImageArch } from './environment.js';
+export { EMULATOR_CPU_CORES } from './emulator-startup.js';
 export { HarnessAppPathError, HarnessEmulatorConfigError } from './errors.js';
 export { getRunTargets } from './targets.js';

--- a/packages/platform-android/src/index.ts
+++ b/packages/platform-android/src/index.ts
@@ -9,6 +9,6 @@ export {
   resolveAvdCachingEnabled,
 } from './avd-config.js';
 export { getHostAndroidSystemImageArch } from './environment.js';
-export { EMULATOR_CPU_CORES } from './emulator-startup.js';
+export { getEmulatorCpuCores } from './emulator-startup.js';
 export { HarnessAppPathError, HarnessEmulatorConfigError } from './errors.js';
 export { getRunTargets } from './targets.js';

--- a/packages/platform-android/src/instance.ts
+++ b/packages/platform-android/src/instance.ts
@@ -29,6 +29,7 @@ import {
   ensureAndroidEmulatorEnvironment,
   getHostAndroidSystemImageArch,
 } from './environment.js';
+import { warnIfEmulatorAccelerationUnavailable } from './emulator-startup.js';
 import { isInteractive } from '@react-native-harness/tools';
 import fs from 'node:fs';
 import { createAndroidAppSession } from './app-session.js';
@@ -90,6 +91,7 @@ const startAndWaitForBoot = async ({
   mode?: Parameters<typeof adbModule.startEmulator>[1];
 }): Promise<string> => {
   await ensureAndroidEmulatorAvailable();
+  await warnIfEmulatorAccelerationUnavailable();
   await adbModule.startEmulator(emulatorName, mode);
   return adbModule.waitForBoot(emulatorName, signal);
 };

--- a/packages/tools/src/__tests__/device-core-budget.test.ts
+++ b/packages/tools/src/__tests__/device-core-budget.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDeviceCoreBudget,
+  MAX_DEVICE_CORE_BUDGET,
+  MIN_DEVICE_CORE_BUDGET,
+} from '../device-core-budget.js';
+
+describe('getDeviceCoreBudget', () => {
+  it('documents the supported device-core range', () => {
+    expect(MIN_DEVICE_CORE_BUDGET).toBe(2);
+    expect(MAX_DEVICE_CORE_BUDGET).toBe(4);
+  });
+
+  it.each([
+    [1, 2],
+    [2, 2],
+    [3, 2],
+    [4, 2],
+    [7, 3],
+    [8, 4],
+    [32, 4],
+  ])('allocates %i host cores as a %i-core device budget', (host, expected) => {
+    expect(getDeviceCoreBudget(host)).toBe(expected);
+  });
+});

--- a/packages/tools/src/device-core-budget.ts
+++ b/packages/tools/src/device-core-budget.ts
@@ -1,0 +1,20 @@
+/**
+ * Smallest viable vCPU allocation for a guest device (2 cores).
+ */
+export const MIN_DEVICE_CORE_BUDGET = 2;
+
+/**
+ * The emulator's useful vCPU ceiling (4 cores); allocating more does not
+ * improve it.
+ */
+export const MAX_DEVICE_CORE_BUDGET = 4;
+
+/**
+ * Derives the vCPU budget for a guest device from host parallelism.
+ */
+export const getDeviceCoreBudget = (hostParallelism: number): number => {
+  return Math.min(
+    Math.max(Math.floor(hostParallelism / 2), MIN_DEVICE_CORE_BUDGET),
+    MAX_DEVICE_CORE_BUDGET
+  );
+};

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -14,3 +14,4 @@ export * from './harness-artifacts.js';
 export * from './regex.js';
 export * from './isInteractive.js';
 export * from './diagnostics.js';
+export * from './device-core-budget.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
       '@react-native-harness/config':
         specifier: workspace:*
         version: link:../config
+      '@react-native-harness/platform-android':
+        specifier: workspace:*
+        version: link:../platform-android
     devDependencies:
       tsup:
         specifier: ^8.5.1


### PR DESCRIPTION
## User impact

Android Harness runs make better use of larger development machines, so local emulator tests can start and run faster. Small CI runners behave as before.