### PR TITLE
fix: support Xcode 26.4.1 in iOS CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -138,10 +138,10 @@ jobs:
           node-version: '24.10.0'
           cache: 'pnpm'
 
-      - name: Setup Xcode 26
+      - name: Setup Xcode 26.4.1
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.4.1'
 
       - name: Install Watchman
         run: brew install watchman
@@ -414,10 +414,10 @@ jobs:
           node-version: '24.10.0'
           cache: 'pnpm'
 
-      - name: Setup Xcode 26
+      - name: Setup Xcode 26.4.1
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '26.0'
+          xcode-version: '26.4.1'
 
       - name: Install Watchman
         run: brew install watchman

--- a/apps/playground/ios/Podfile
+++ b/apps/playground/ios/Podfile
@@ -30,5 +30,24 @@ target 'HarnessPlayground' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Workaround for Xcode 26: newer Apple Clang breaks consteval in fmt 11.0.2.
+    # Patch base.h to disable consteval since the header doesn't check for a
+    # pre-defined FMT_USE_CONSTEVAL.
+    fmt_base = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
+
+    if File.exist?(fmt_base)
+      content = File.read(fmt_base)
+      unless content.include?('Xcode 26 workaround')
+        patched = content.gsub(
+          /^(#elif defined\(__cpp_consteval\)\n#  define FMT_USE_CONSTEVAL) 1/,
+          "// Xcode 26 workaround: disable consteval\n\\1 0"
+        )
+        if patched != content
+          File.chmod(0644, fmt_base)
+          File.write(fmt_base, patched)
+        end
+      end
+    end
   end
 end

--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -79,7 +79,7 @@ export default {
     }),
     applePlatform({
       name: 'ios',
-      device: appleSimulator('iPhone 17 Pro', '26.2'),
+      device: appleSimulator('iPhone 17 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
     }),
     applePlatform({

--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -79,12 +79,12 @@ export default {
     }),
     applePlatform({
       name: 'ios',
-      device: appleSimulator('iPhone 16 Pro', '26.4'),
+      device: appleSimulator('iPhone 17 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
     }),
     applePlatform({
       name: 'ios-crash-pre-rn',
-      device: appleSimulator('iPhone 16 Pro', '26.4'),
+      device: appleSimulator('iPhone 17 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
       appLaunchOptions: {
         environment: {
@@ -94,7 +94,7 @@ export default {
     }),
     applePlatform({
       name: 'ios-crash-delayed',
-      device: appleSimulator('iPhone 16 Pro', '26.4'),
+      device: appleSimulator('iPhone 17 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
       appLaunchOptions: {
         environment: {

--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -79,12 +79,12 @@ export default {
     }),
     applePlatform({
       name: 'ios',
-      device: appleSimulator('iPhone 17 Pro', '26.4'),
+      device: appleSimulator('iPhone 16 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
     }),
     applePlatform({
       name: 'ios-crash-pre-rn',
-      device: appleSimulator('iPhone 16 Pro', '18.6'),
+      device: appleSimulator('iPhone 16 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
       appLaunchOptions: {
         environment: {
@@ -94,7 +94,7 @@ export default {
     }),
     applePlatform({
       name: 'ios-crash-delayed',
-      device: appleSimulator('iPhone 16 Pro', '18.6'),
+      device: appleSimulator('iPhone 16 Pro', '26.4'),
       bundleId: 'com.harnessplayground',
       appLaunchOptions: {
         environment: {


### PR DESCRIPTION
## What is this?

This PR updates iOS CI to Xcode 26.4.1 and adds a CocoaPods workaround for fmt 11.0.2, whose consteval path is incompatible with newer Apple Clang versions in Xcode 26.

## How does it work?

The iOS E2E and crash-validation jobs select Xcode 26.4.1. During CocoaPods installation, the playground Podfile conditionally patches the fmt `base.h` header to set `FMT_USE_CONSTEVAL` to `0`; the patch is skipped when the header is absent or already marked as applied.

## Why is this useful?

It keeps both iOS CI paths on the intended Xcode release while preventing the fmt compilation failure that would otherwise block playground builds with Xcode 26.