### PR TITLE
Add a configurable 'runtime' environment reset strategy between test files

### DIFF
--- a/.nx/version-plans/add-environment-reset-strategies.md
+++ b/.nx/version-plans/add-environment-reset-strategies.md
@@ -1,0 +1,5 @@
+---
+__default__: minor
+---
+
+`resetEnvironmentBetweenTestFiles` now accepts `'runtime'` as a faster alternative to a full app restart between test files. Instead of relaunching the app, the runtime is reset in place, which noticeably speeds up suites with many test files while keeping each file isolated. Existing `true`/`false` settings keep working as before.

--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -122,7 +122,7 @@ export default {
 
   permissions: true,
   detectNativeCrashes: true,
-  resetEnvironmentBetweenTestFiles: true,
+  resetEnvironmentBetweenTestFiles: 'runtime',
   unstable__enableMetroCache: true,
   unstable__skipAlreadyIncludedModules: false,
   forwardClientLogs: true,

--- a/packages/bridge/src/__tests__/client.test.ts
+++ b/packages/bridge/src/__tests__/client.test.ts
@@ -73,7 +73,7 @@ describe('connectToHarness transport injection', () => {
     const mockTransport = createMockTransport();
     const handlePromise = connectToHarness(
       'ws://unused',
-      { runTests: vi.fn() },
+      { runTests: vi.fn(), resetEnvironment: vi.fn() },
       { transport: mockTransport.transport },
     );
 

--- a/packages/bridge/src/client.ts
+++ b/packages/bridge/src/client.ts
@@ -19,6 +19,7 @@ import type {
 
 export type HarnessCallbacks = {
   runTests: (path: string, options: TestExecutionOptions) => Promise<TestSuiteResult>;
+  resetEnvironment: () => Promise<void>;
 };
 
 export type HarnessHandle = {

--- a/packages/bridge/src/server.ts
+++ b/packages/bridge/src/server.ts
@@ -44,6 +44,7 @@ const noop = (): void => undefined;
 export type AppConnection = {
   readonly device: DeviceDescriptor;
   runTests: (path: string, options: TestExecutionOptions) => Promise<TestSuiteResult>;
+  resetEnvironment: () => Promise<void>;
 };
 
 export type HarnessBridgeEvents = {
@@ -223,6 +224,7 @@ export const createHarnessBridge = async (
           const conn: AppConnection = {
             device: controlMessage.device,
             runTests: (testPath, opts) => rpc.invoke('runTests', testPath, opts),
+            resetEnvironment: () => rpc.invoke('resetEnvironment'),
           };
 
           readyConnection = conn;

--- a/packages/bridge/src/shared.ts
+++ b/packages/bridge/src/shared.ts
@@ -143,6 +143,7 @@ export type BridgeClientFunctions = {
     path: string,
     options: TestExecutionOptions
   ) => Promise<TestSuiteResult>;
+  resetEnvironment: () => Promise<void>;
 };
 
 export type BinaryDataReference = {

--- a/packages/bundler-metro/eslint.config.mjs
+++ b/packages/bundler-metro/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
         'error',
         {
           ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}'],
-          ignoredDependencies: ['@react-native-harness/babel-preset', 'vitest'],
+          ignoredDependencies: ['@react-native-harness/babel-preset', 'vite', 'vitest'],
         },
       ],
     },

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -80,7 +80,17 @@ export const ConfigSchema = z
           'so the first bundle is ready sooner. Disable to defer the first bundle build until app startup.'
       ),
 
-    resetEnvironmentBetweenTestFiles: z.boolean().optional().default(true),
+    resetEnvironmentBetweenTestFiles: z
+      .union([z.boolean(), z.enum(['process', 'runtime'])])
+      .optional()
+      .default(true)
+      .describe(
+        'Controls how the environment is reset between test files. `true` (default) and `\'process\'` ' +
+          'kill and cold-restart the app process. `\'runtime\'` reloads the JS runtime in place ' +
+          '(DevSettings.reload() / window.location.reload()), which is cheaper but escalates to a ' +
+          'process restart if the reload fails or the app does not reconnect in time. `false` disables ' +
+          'resetting the environment between test files entirely.'
+      ),
     unstable__skipAlreadyIncludedModules: z.boolean().optional().default(false),
     unstable__enableMetroCache: z.boolean().optional().default(false),
     permissions: z

--- a/packages/jest/src/__tests__/bridge.test.ts
+++ b/packages/jest/src/__tests__/bridge.test.ts
@@ -37,8 +37,12 @@ afterEach(async () => {
   await new Promise((r) => setTimeout(r, 10));
 });
 
-const connect = (callbacks: Parameters<typeof connectToHarness>[1] = { runTests: vi.fn() }) =>
-  connectToHarness(`ws://127.0.0.1:${bridgePort}`, callbacks);
+const connect = (
+  callbacks: Parameters<typeof connectToHarness>[1] = {
+    runTests: vi.fn(),
+    resetEnvironment: vi.fn(),
+  },
+) => connectToHarness(`ws://127.0.0.1:${bridgePort}`, callbacks);
 
 const device = {
   platform: 'ios' as const,
@@ -140,7 +144,7 @@ describe('bridge: createHarnessBridge + connectToHarness', () => {
       const runTestsCb = vi.fn(async () => suiteResult);
 
       const connectionPromise = bridge.nextConnection();
-      const handle = await connect({ runTests: runTestsCb });
+      const handle = await connect({ runTests: runTestsCb, resetEnvironment: vi.fn() });
       handle.reportReady(device);
 
       const conn = await connectionPromise;
@@ -157,6 +161,7 @@ describe('bridge: createHarnessBridge + connectToHarness', () => {
       const firstHandle = await connect({
         runTests: async (): Promise<TestSuiteResult> =>
           await new Promise<TestSuiteResult>(() => undefined),
+        resetEnvironment: vi.fn(),
       });
       firstHandle.reportReady(device);
 

--- a/packages/jest/src/__tests__/crash-monitor.test.ts
+++ b/packages/jest/src/__tests__/crash-monitor.test.ts
@@ -236,4 +236,88 @@ describe('createCrashMonitor', () => {
     expect(session.removeListener).toHaveBeenCalledOnce();
     expect(cm.isAlive()).toBe(false);
   });
+
+  describe('expectDisconnect', () => {
+    it('suppresses handleBridgeDisconnect while the window is open', async () => {
+      const { session } = createAppSessionMock({ status: 'running' });
+      const cm = createCrashMonitor({ appSession: session });
+      const watch = cm.watch('test.ts', 'execution');
+      watch.promise.catch(noop);
+
+      const closeWindow = cm.expectDisconnect();
+      cm.handleBridgeDisconnect();
+      await waitForClassification();
+
+      const settled = vi.fn();
+      watch.promise.then(settled, settled);
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
+
+      closeWindow();
+      watch.cancel();
+    });
+
+    it('resumes classifying disconnects once the window closes', async () => {
+      const { session } = createAppSessionMock({ status: 'running' });
+      const cm = createCrashMonitor({ appSession: session });
+      const watch = cm.watch('test.ts', 'execution');
+      watch.promise.catch(noop);
+
+      const closeWindow = cm.expectDisconnect();
+      closeWindow();
+
+      cm.handleBridgeDisconnect();
+
+      await expect(watch.promise).rejects.toBeInstanceOf(RuntimeDisconnectError);
+    });
+
+    it('keeps the window open until every opener has closed it (nested windows)', async () => {
+      const { session } = createAppSessionMock({ status: 'running' });
+      const cm = createCrashMonitor({ appSession: session });
+      const watch = cm.watch('test.ts', 'execution');
+      watch.promise.catch(noop);
+
+      const closeFirst = cm.expectDisconnect();
+      const closeSecond = cm.expectDisconnect();
+      closeFirst();
+
+      cm.handleBridgeDisconnect();
+      await waitForClassification();
+
+      const settled = vi.fn();
+      watch.promise.then(settled, settled);
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
+
+      closeSecond();
+      watch.cancel();
+    });
+
+    it('ignores a redundant close() call', async () => {
+      const { session } = createAppSessionMock({ status: 'running' });
+      const cm = createCrashMonitor({ appSession: session });
+      const watch = cm.watch('test.ts', 'execution');
+      watch.promise.catch(noop);
+
+      const closeWindow = cm.expectDisconnect();
+      closeWindow();
+      closeWindow();
+
+      cm.handleBridgeDisconnect();
+
+      await expect(watch.promise).rejects.toBeInstanceOf(RuntimeDisconnectError);
+    });
+
+    it('clears the expected-disconnect window on dispose', async () => {
+      const { session } = createAppSessionMock({ status: 'running' });
+      const cm = createCrashMonitor({ appSession: session });
+      cm.expectDisconnect();
+
+      await cm.dispose();
+
+      // A disconnect after dispose should not throw or hang; monitoring is
+      // fully torn down regardless of the window state.
+      expect(() => cm.handleBridgeDisconnect()).not.toThrow();
+    });
+  });
 });

--- a/packages/jest/src/__tests__/environment-reset.test.ts
+++ b/packages/jest/src/__tests__/environment-reset.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { resolveResetStrategyKind } from '../environment-reset.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createProcessResetStrategy,
+  createRuntimeResetStrategy,
+  resolveResetStrategyKind,
+  withEscalation,
+  type EnvironmentResetStrategy,
+} from '../environment-reset.js';
 
 describe('resolveResetStrategyKind', () => {
   it('normalizes true to the process strategy', () => {
@@ -16,5 +22,200 @@ describe('resolveResetStrategyKind', () => {
 
   it('passes through the runtime string value', () => {
     expect(resolveResetStrategyKind('runtime')).toBe('runtime');
+  });
+});
+
+describe('createProcessResetStrategy', () => {
+  it('has kind "process" and delegates to the injected restart function', async () => {
+    const restart = vi.fn(async () => undefined);
+    const strategy = createProcessResetStrategy({ restart });
+
+    expect(strategy.kind).toBe('process');
+    await strategy.reset({ testFilePath: '/tests/example.harness.ts' });
+
+    expect(restart).toHaveBeenCalledWith('/tests/example.harness.ts');
+  });
+
+  it('propagates restart failures', async () => {
+    const restart = vi.fn(async () => {
+      throw new Error('restart failed');
+    });
+    const strategy = createProcessResetStrategy({ restart });
+
+    await expect(
+      strategy.reset({ testFilePath: '/tests/example.harness.ts' })
+    ).rejects.toThrow('restart failed');
+  });
+});
+
+describe('createRuntimeResetStrategy', () => {
+  const testFilePath = '/tests/example.harness.ts';
+
+  it('has kind "runtime" and resets via the connection then waits for reconnect', async () => {
+    const callOrder: string[] = [];
+    const closeWindow = vi.fn();
+    const connection = {
+      resetEnvironment: vi.fn(async () => {
+        callOrder.push('resetEnvironment');
+      }),
+    };
+    const waitForReconnect = vi.fn(async () => {
+      callOrder.push('waitForReconnect-started');
+    });
+
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => connection,
+      expectDisconnect: () => {
+        callOrder.push('expectDisconnect');
+        return closeWindow;
+      },
+      waitForReconnect,
+      timeoutMs: 1000,
+    });
+
+    expect(strategy.kind).toBe('runtime');
+    await strategy.reset({ testFilePath });
+
+    expect(callOrder).toEqual([
+      'expectDisconnect',
+      'waitForReconnect-started',
+      'resetEnvironment',
+    ]);
+    expect(waitForReconnect).toHaveBeenCalledWith(expect.any(AbortSignal));
+    expect(closeWindow).toHaveBeenCalledOnce();
+  });
+
+  it('starts waiting for reconnect before firing the RPC', async () => {
+    const callOrder: string[] = [];
+    const connection = {
+      resetEnvironment: vi.fn(async () => {
+        callOrder.push('resetEnvironment');
+      }),
+    };
+    const waitForReconnect = vi.fn(() => {
+      callOrder.push('waitForReconnect-called');
+      return Promise.resolve();
+    });
+
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => connection,
+      expectDisconnect: () => () => undefined,
+      waitForReconnect,
+      timeoutMs: 1000,
+    });
+
+    await strategy.reset({ testFilePath });
+
+    expect(callOrder).toEqual(['waitForReconnect-called', 'resetEnvironment']);
+  });
+
+  it('throws when there is no active app connection', async () => {
+    const expectDisconnect = vi.fn();
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => null,
+      expectDisconnect,
+      waitForReconnect: vi.fn(async () => undefined),
+      timeoutMs: 1000,
+    });
+
+    await expect(strategy.reset({ testFilePath })).rejects.toThrow(
+      'No active app connection'
+    );
+    expect(expectDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('closes the expected-disconnect window even when the RPC call fails', async () => {
+    const closeWindow = vi.fn();
+    const connection = {
+      resetEnvironment: vi.fn(async () => {
+        throw new Error('rpc failed');
+      }),
+    };
+
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => connection,
+      expectDisconnect: () => closeWindow,
+      waitForReconnect: vi.fn(async () => undefined),
+      timeoutMs: 1000,
+    });
+
+    await expect(strategy.reset({ testFilePath })).rejects.toThrow('rpc failed');
+    expect(closeWindow).toHaveBeenCalledOnce();
+  });
+
+  it('closes the expected-disconnect window even when reconnect times out', async () => {
+    const closeWindow = vi.fn();
+    const connection = { resetEnvironment: vi.fn(async () => undefined) };
+
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => connection,
+      expectDisconnect: () => closeWindow,
+      waitForReconnect: vi.fn(async () => {
+        throw new Error('reconnect timed out');
+      }),
+      timeoutMs: 1000,
+    });
+
+    await expect(strategy.reset({ testFilePath })).rejects.toThrow(
+      'reconnect timed out'
+    );
+    expect(closeWindow).toHaveBeenCalledOnce();
+  });
+});
+
+describe('withEscalation', () => {
+  const testFilePath = '/tests/example.harness.ts';
+
+  const makeStrategy = (
+    kind: EnvironmentResetStrategy['kind'],
+    reset: EnvironmentResetStrategy['reset']
+  ): EnvironmentResetStrategy => ({ kind, reset });
+
+  it('reports the primary strategy kind', () => {
+    const primary = makeStrategy('runtime', async () => undefined);
+    const fallback = makeStrategy('process', async () => undefined);
+
+    expect(withEscalation(primary, fallback).kind).toBe('runtime');
+  });
+
+  it('does not call the fallback when the primary succeeds', async () => {
+    const fallbackReset = vi.fn(async () => undefined);
+    const primary = makeStrategy('runtime', async () => undefined);
+    const fallback = makeStrategy('process', fallbackReset);
+    const onEscalate = vi.fn();
+
+    await withEscalation(primary, fallback, { onEscalate }).reset({ testFilePath });
+
+    expect(fallbackReset).not.toHaveBeenCalled();
+    expect(onEscalate).not.toHaveBeenCalled();
+  });
+
+  it('escalates to the fallback when the primary fails', async () => {
+    const primaryError = new Error('runtime reset failed');
+    const fallbackReset = vi.fn(async () => undefined);
+    const primary = makeStrategy('runtime', async () => {
+      throw primaryError;
+    });
+    const fallback = makeStrategy('process', fallbackReset);
+    const onEscalate = vi.fn();
+
+    await withEscalation(primary, fallback, { onEscalate }).reset({ testFilePath });
+
+    expect(fallbackReset).toHaveBeenCalledWith({ testFilePath });
+    expect(onEscalate).toHaveBeenCalledWith(primaryError);
+  });
+
+  it('propagates the fallback error when both strategies fail', async () => {
+    const fallbackError = new Error('process reset also failed');
+    const primary = makeStrategy('runtime', async () => {
+      throw new Error('runtime reset failed');
+    });
+    const fallback = makeStrategy('process', async () => {
+      throw fallbackError;
+    });
+
+    await expect(
+      withEscalation(primary, fallback).reset({ testFilePath })
+    ).rejects.toBe(fallbackError);
   });
 });

--- a/packages/jest/src/__tests__/environment-reset.test.ts
+++ b/packages/jest/src/__tests__/environment-reset.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveResetStrategyKind } from '../environment-reset.js';
+
+describe('resolveResetStrategyKind', () => {
+  it('normalizes true to the process strategy', () => {
+    expect(resolveResetStrategyKind(true)).toBe('process');
+  });
+
+  it('normalizes false to null (no reset)', () => {
+    expect(resolveResetStrategyKind(false)).toBeNull();
+  });
+
+  it('passes through the process string value', () => {
+    expect(resolveResetStrategyKind('process')).toBe('process');
+  });
+
+  it('passes through the runtime string value', () => {
+    expect(resolveResetStrategyKind('runtime')).toBe('runtime');
+  });
+});

--- a/packages/jest/src/__tests__/environment-reset.test.ts
+++ b/packages/jest/src/__tests__/environment-reset.test.ts
@@ -70,6 +70,7 @@ describe('createRuntimeResetStrategy', () => {
         return closeWindow;
       },
       waitForReconnect,
+      isDisconnectError: () => false,
       timeoutMs: 1000,
     });
 
@@ -101,6 +102,7 @@ describe('createRuntimeResetStrategy', () => {
       getConnection: () => connection,
       expectDisconnect: () => () => undefined,
       waitForReconnect,
+      isDisconnectError: () => false,
       timeoutMs: 1000,
     });
 
@@ -115,6 +117,7 @@ describe('createRuntimeResetStrategy', () => {
       getConnection: () => null,
       expectDisconnect,
       waitForReconnect: vi.fn(async () => undefined),
+      isDisconnectError: () => false,
       timeoutMs: 1000,
     });
 
@@ -136,6 +139,7 @@ describe('createRuntimeResetStrategy', () => {
       getConnection: () => connection,
       expectDisconnect: () => closeWindow,
       waitForReconnect: vi.fn(async () => undefined),
+      isDisconnectError: () => false,
       timeoutMs: 1000,
     });
 
@@ -153,6 +157,7 @@ describe('createRuntimeResetStrategy', () => {
       waitForReconnect: vi.fn(async () => {
         throw new Error('reconnect timed out');
       }),
+      isDisconnectError: () => false,
       timeoutMs: 1000,
     });
 
@@ -160,6 +165,88 @@ describe('createRuntimeResetStrategy', () => {
       'reconnect timed out'
     );
     expect(closeWindow).toHaveBeenCalledOnce();
+  });
+
+  it('treats a disconnect-flavored RPC rejection as reload-in-flight and succeeds', async () => {
+    const disconnectError = new Error('app bridge disconnected');
+    const connection = {
+      resetEnvironment: vi.fn(async () => {
+        throw disconnectError;
+      }),
+    };
+    const waitForReconnect = vi.fn(async () => undefined);
+
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => connection,
+      expectDisconnect: () => () => undefined,
+      waitForReconnect,
+      isDisconnectError: (error) => error === disconnectError,
+      timeoutMs: 1000,
+    });
+
+    await expect(strategy.reset({ testFilePath })).resolves.toBeUndefined();
+    expect(waitForReconnect).toHaveBeenCalledOnce();
+  });
+
+  it('still throws on a non-disconnect RPC rejection', async () => {
+    const connection = {
+      resetEnvironment: vi.fn(async () => {
+        throw new Error('rpc failed');
+      }),
+    };
+
+    const strategy = createRuntimeResetStrategy({
+      getConnection: () => connection,
+      expectDisconnect: () => () => undefined,
+      waitForReconnect: vi.fn(async () => undefined),
+      isDisconnectError: (error) =>
+        error instanceof Error && error.message === 'app bridge disconnected',
+      timeoutMs: 1000,
+    });
+
+    await expect(strategy.reset({ testFilePath })).rejects.toThrow('rpc failed');
+  });
+
+  it('does not leave an unhandled rejection when the RPC fails before the reconnect wait settles', async () => {
+    let rejectReconnect!: (error: Error) => void;
+    const waitForReconnect = vi.fn(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectReconnect = reject;
+        })
+    );
+    const connection = {
+      resetEnvironment: vi.fn(async () => {
+        throw new Error('rpc failed');
+      }),
+    };
+
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const strategy = createRuntimeResetStrategy({
+        getConnection: () => connection,
+        expectDisconnect: () => () => undefined,
+        waitForReconnect,
+        isDisconnectError: () => false,
+        timeoutMs: 1000,
+      });
+
+      await expect(strategy.reset({ testFilePath })).rejects.toThrow('rpc failed');
+
+      // Simulate the reconnect timeout firing after the strategy already
+      // threw; the strategy must have attached a rejection handler.
+      rejectReconnect(new Error('reconnect timed out'));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
   });
 });
 

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -127,6 +127,7 @@ const makeSession = (overrides: Partial<HarnessSession> = {}): HarnessSession =>
   ensureAppReady: vi.fn(resolveUndefined),
   runTestFile: vi.fn(async () => makeHarnessResult()),
   restartApp: vi.fn(resolveUndefined),
+  resetEnvironment: vi.fn(resolveUndefined),
   resetCrashState: vi.fn(),
   flushClientLogs: vi.fn(() => []),
   callHook: vi.fn(resolveUndefined),
@@ -582,7 +583,7 @@ describe('executeRun', () => {
   });
 
   describe('resetEnvironmentBetweenTestFiles', () => {
-    it('calls restartApp before the second test but not the first', async () => {
+    it('calls resetEnvironment before the second test but not the first', async () => {
       const session = makeSession({
         config: {
           metroPort: 8081,
@@ -603,8 +604,58 @@ describe('executeRun', () => {
         makeGlobalConfig(),
       );
 
-      // restartApp should be called for tests 2 and 3, not test 1.
-      expect(session.restartApp).toHaveBeenCalledTimes(2);
+      // resetEnvironment should be called for tests 2 and 3, not test 1.
+      expect(session.resetEnvironment).toHaveBeenCalledTimes(2);
+      expect(session.restartApp).not.toHaveBeenCalled();
+    });
+
+    it('calls resetEnvironment with the "runtime" strategy configured', async () => {
+      const session = makeSession({
+        config: {
+          metroPort: 8081,
+          resetEnvironmentBetweenTestFiles: 'runtime',
+          detectNativeCrashes: false,
+          runners: [
+            { platformId: 'android', name: 'android' },
+            { platformId: 'ios', name: 'ios' },
+          ],
+        } as HarnessSession['config'],
+      });
+
+      await executeRun(
+        session,
+        [makeTest('/a.ts'), makeTest('/b.ts')],
+        makeWatcher(),
+        makeEmitEvent().emitEvent,
+        makeGlobalConfig(),
+      );
+
+      expect(session.resetEnvironment).toHaveBeenCalledTimes(1);
+      expect(session.resetEnvironment).toHaveBeenCalledWith('/b.ts');
+    });
+
+    it('does not call resetEnvironment when resetEnvironmentBetweenTestFiles is false', async () => {
+      const session = makeSession({
+        config: {
+          metroPort: 8081,
+          resetEnvironmentBetweenTestFiles: false,
+          detectNativeCrashes: false,
+          runners: [
+            { platformId: 'android', name: 'android' },
+            { platformId: 'ios', name: 'ios' },
+          ],
+        } as HarnessSession['config'],
+      });
+
+      await executeRun(
+        session,
+        [makeTest('/a.ts'), makeTest('/b.ts')],
+        makeWatcher(),
+        makeEmitEvent().emitEvent,
+        makeGlobalConfig(),
+      );
+
+      expect(session.resetEnvironment).not.toHaveBeenCalled();
     });
 
     it('restarts after a test case timeout before the next runnable file', async () => {
@@ -791,6 +842,7 @@ describe('executeRun', () => {
       );
 
       expect(session.restartApp).not.toHaveBeenCalled();
+      expect(session.resetEnvironment).not.toHaveBeenCalled();
       expect(mockRunHarnessTestFile).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/jest/src/__tests__/harness-session.test.ts
+++ b/packages/jest/src/__tests__/harness-session.test.ts
@@ -3,6 +3,7 @@ import type { AppConnection } from '@react-native-harness/bridge/server';
 import {
   getSignalExitCodeForRunState,
   waitForBridgeDisconnectOrTimeout,
+  waitForNextConnected,
   waitForStartupCrash,
   type HarnessRunState,
 } from '../harness-session.js';
@@ -71,6 +72,65 @@ describe('waitForBridgeDisconnectOrTimeout', () => {
         timeoutMs: 10,
       }),
     ).resolves.toBe(false);
+  });
+});
+
+describe('waitForNextConnected', () => {
+  const createConnectableBridge = () => {
+    let listener: (() => void) | null = null;
+    const bridge: Pick<
+      import('@react-native-harness/bridge/server').HarnessBridge,
+      'on' | 'off'
+    > = {
+      on: vi.fn((event, l) => {
+        if (event === 'connected') listener = l as () => void;
+      }),
+      off: vi.fn((event, l) => {
+        if (event === 'connected' && listener === l) listener = null;
+      }),
+    };
+    return { bridge, emitConnected: () => listener?.() };
+  };
+
+  it('resolves when the bridge emits a connected event', async () => {
+    const { bridge, emitConnected } = createConnectableBridge();
+    const controller = new AbortController();
+
+    const waitPromise = waitForNextConnected({ bridge, signal: controller.signal });
+    emitConnected();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+  });
+
+  it('rejects when the signal aborts before a connected event', async () => {
+    const { bridge } = createConnectableBridge();
+    const controller = new AbortController();
+
+    const waitPromise = waitForNextConnected({ bridge, signal: controller.signal });
+    controller.abort(new DOMException('Aborted', 'AbortError'));
+
+    await expect(waitPromise).rejects.toThrow('Aborted');
+  });
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const { bridge } = createConnectableBridge();
+    const controller = new AbortController();
+    controller.abort(new DOMException('Aborted', 'AbortError'));
+
+    await expect(
+      waitForNextConnected({ bridge, signal: controller.signal }),
+    ).rejects.toThrow('Aborted');
+  });
+
+  it('unsubscribes the connected listener once settled', async () => {
+    const { bridge, emitConnected } = createConnectableBridge();
+    const controller = new AbortController();
+
+    const waitPromise = waitForNextConnected({ bridge, signal: controller.signal });
+    emitConnected();
+    await waitPromise;
+
+    expect(bridge.off).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/jest/src/__tests__/harness-session.test.ts
+++ b/packages/jest/src/__tests__/harness-session.test.ts
@@ -16,6 +16,7 @@ const createConnection = (): AppConnection => ({
     osVersion: '18.0',
   },
   runTests: vi.fn(),
+  resetEnvironment: vi.fn(),
 });
 
 const createBridge = (connection: AppConnection | null) => {

--- a/packages/jest/src/__tests__/index.test.ts
+++ b/packages/jest/src/__tests__/index.test.ts
@@ -26,6 +26,7 @@ const mockSession: HarnessSession = {
     duration: 0,
   })),
   restartApp: vi.fn(resolveUndefined),
+  resetEnvironment: vi.fn(resolveUndefined),
   resetCrashState: vi.fn(),
   flushClientLogs: vi.fn(() => []),
   callHook: vi.fn(resolveUndefined),

--- a/packages/jest/src/crash-monitor.ts
+++ b/packages/jest/src/crash-monitor.ts
@@ -40,6 +40,13 @@ export type CrashMonitor = {
   reset: () => void;
   setAppSession: (session: AppSession | null) => void;
   handleBridgeDisconnect: () => void;
+  /**
+   * Opens a window during which handleBridgeDisconnect() is suppressed,
+   * for use around operations (like a runtime reset) that intentionally
+   * disconnect the bridge without the app process dying. Returns a closer
+   * that ends the window; safe to call multiple times or nest.
+   */
+  expectDisconnect: () => () => void;
   dispose: () => Promise<void>;
 };
 
@@ -131,6 +138,7 @@ export const createCrashMonitor = ({
 
   let currentTestFilePath = '';
   let currentPhase: NativeCrashPhase = 'startup';
+  let expectedDisconnectDepth = 0;
   const watchers = new Set<(err: HarnessRuntimeFailure) => void>();
 
   const notifyFailure = (err: HarnessRuntimeFailure) => {
@@ -273,6 +281,19 @@ export const createCrashMonitor = ({
     return { promise, cancel };
   };
 
+  const expectDisconnect = (): (() => void) => {
+    expectedDisconnectDepth += 1;
+    let closed = false;
+
+    return () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      expectedDisconnectDepth = Math.max(0, expectedDisconnectDepth - 1);
+    };
+  };
+
   return {
     watch,
     isAlive: () => alive,
@@ -289,15 +310,22 @@ export const createCrashMonitor = ({
       watchers.clear();
       isResolvingCrash = false;
       currentTestFilePath = '';
+      expectedDisconnectDepth = 0;
       clearPendingTimer();
     },
     setAppSession,
     handleBridgeDisconnect: () => {
+      if (expectedDisconnectDepth > 0) {
+        crashLogger.debug('ignoring expected bridge disconnect');
+        return;
+      }
       startCrashResolution('bridge-disconnect');
     },
+    expectDisconnect,
     dispose: async () => {
       disposed = true;
       monitoring = false;
+      expectedDisconnectDepth = 0;
       watchers.clear();
       isResolvingCrash = false;
       clearPendingTimer();

--- a/packages/jest/src/environment-reset.ts
+++ b/packages/jest/src/environment-reset.ts
@@ -1,6 +1,13 @@
+import { getTimeoutSignal } from '@react-native-harness/tools';
 import type { Config as HarnessConfig } from '@react-native-harness/config';
 
 export type ResetStrategyKind = 'process' | 'runtime';
+
+export type EnvironmentResetStrategy = {
+  readonly kind: ResetStrategyKind;
+  // Post-condition: bridge connected, runtime ready, crash-monitor state consistent.
+  reset(ctx: { testFilePath: string }): Promise<void>;
+};
 
 /**
  * Normalizes the `resetEnvironmentBetweenTestFiles` config value into a
@@ -18,3 +25,93 @@ export const resolveResetStrategyKind = (
   }
   return value;
 };
+
+export type ProcessResetStrategyDeps = {
+  // Shared with restartApp; killing and relaunching the app process.
+  restart: (testFilePath: string) => Promise<void>;
+};
+
+/**
+ * The 'process' strategy: kill and cold-restart the app process. This is
+ * the same implementation `restartApp` uses for crash/timeout recovery.
+ */
+export const createProcessResetStrategy = (
+  deps: ProcessResetStrategyDeps
+): EnvironmentResetStrategy => ({
+  kind: 'process',
+  reset: ({ testFilePath }) => deps.restart(testFilePath),
+});
+
+export type RuntimeResetConnection = {
+  resetEnvironment: () => Promise<void>;
+};
+
+export type RuntimeResetStrategyDeps = {
+  // Returns the active app connection, or null if there isn't one.
+  getConnection: () => RuntimeResetConnection | null;
+  // Opens a window that suppresses crash-monitor disconnect handling;
+  // returns a closer to end the window.
+  expectDisconnect: () => () => void;
+  // Resolves the next time the bridge reports a 'connected' event, or
+  // rejects when `signal` aborts.
+  waitForReconnect: (signal: AbortSignal) => Promise<void>;
+  // Reconnect timeout in ms (the configured bundleStartTimeout).
+  timeoutMs: number;
+};
+
+/**
+ * The 'runtime' strategy: reload the JS runtime in place (DevSettings.reload()
+ * on native, window.location.reload() on web) via the resetEnvironment RPC,
+ * and wait for the bridge to reconnect. The app process stays alive
+ * throughout, so the crash monitor's expected-disconnect window is used to
+ * avoid misclassifying the intentional disconnect as a runtime failure.
+ */
+export const createRuntimeResetStrategy = (
+  deps: RuntimeResetStrategyDeps
+): EnvironmentResetStrategy => ({
+  kind: 'runtime',
+  reset: async () => {
+    const connection = deps.getConnection();
+    if (!connection) {
+      throw new Error('No active app connection to reset the runtime on');
+    }
+
+    const closeWindow = deps.expectDisconnect();
+    try {
+      // Start listening for the reconnect before firing the RPC, so a fast
+      // reload can't reconnect before we're watching for it.
+      const reconnected = deps.waitForReconnect(getTimeoutSignal(deps.timeoutMs));
+      await connection.resetEnvironment();
+      await reconnected;
+    } finally {
+      closeWindow();
+    }
+  },
+});
+
+export type EscalationOptions = {
+  // Invoked when the primary strategy fails and the fallback is about to run.
+  onEscalate?: (error: unknown) => void;
+};
+
+/**
+ * Wraps a primary strategy so that any failure (no active connection, RPC
+ * error, reconnect timeout, ...) falls back to running `fallback` instead of
+ * propagating the error. The composite reports the primary's `kind`, since
+ * that's the strategy that was requested.
+ */
+export const withEscalation = (
+  primary: EnvironmentResetStrategy,
+  fallback: EnvironmentResetStrategy,
+  options: EscalationOptions = {}
+): EnvironmentResetStrategy => ({
+  kind: primary.kind,
+  reset: async (ctx) => {
+    try {
+      await primary.reset(ctx);
+    } catch (error) {
+      options.onEscalate?.(error);
+      await fallback.reset(ctx);
+    }
+  },
+});

--- a/packages/jest/src/environment-reset.ts
+++ b/packages/jest/src/environment-reset.ts
@@ -1,0 +1,20 @@
+import type { Config as HarnessConfig } from '@react-native-harness/config';
+
+export type ResetStrategyKind = 'process' | 'runtime';
+
+/**
+ * Normalizes the `resetEnvironmentBetweenTestFiles` config value into a
+ * strategy kind, or `null` when no reset should happen between test files
+ * (i.e. the value is `false`).
+ */
+export const resolveResetStrategyKind = (
+  value: HarnessConfig['resetEnvironmentBetweenTestFiles']
+): ResetStrategyKind | null => {
+  if (value === false) {
+    return null;
+  }
+  if (value === true) {
+    return 'process';
+  }
+  return value;
+};

--- a/packages/jest/src/environment-reset.ts
+++ b/packages/jest/src/environment-reset.ts
@@ -1,6 +1,8 @@
 import { getTimeoutSignal } from '@react-native-harness/tools';
 import type { Config as HarnessConfig } from '@react-native-harness/config';
 
+const ignorePromiseRejection = () => undefined;
+
 export type ResetStrategyKind = 'process' | 'runtime';
 
 export type EnvironmentResetStrategy = {
@@ -55,6 +57,10 @@ export type RuntimeResetStrategyDeps = {
   // Resolves the next time the bridge reports a 'connected' event, or
   // rejects when `signal` aborts.
   waitForReconnect: (signal: AbortSignal) => Promise<void>;
+  // Identifies RPC rejections caused by the bridge disconnecting. Inside the
+  // expected-disconnect window these mean the reload tore the runtime down
+  // before the RPC ack flushed — the reload is in flight, not failed.
+  isDisconnectError: (error: unknown) => boolean;
   // Reconnect timeout in ms (the configured bundleStartTimeout).
   timeoutMs: number;
 };
@@ -81,7 +87,22 @@ export const createRuntimeResetStrategy = (
       // Start listening for the reconnect before firing the RPC, so a fast
       // reload can't reconnect before we're watching for it.
       const reconnected = deps.waitForReconnect(getTimeoutSignal(deps.timeoutMs));
-      await connection.resetEnvironment();
+      // Observe the rejection even when the RPC throws first, so the timeout
+      // abort firing later can't become an unhandled rejection. (.catch()
+      // returns a new promise; the original is what gets awaited below.)
+      reconnected.catch(ignorePromiseRejection);
+
+      try {
+        await connection.resetEnvironment();
+      } catch (error) {
+        // The reload can tear the runtime down before the RPC ack flushes.
+        // A disconnect-flavored rejection means the reload is in flight, so
+        // keep waiting for the reconnect; anything else is a real failure.
+        if (!deps.isDisconnectError(error)) {
+          throw error;
+        }
+      }
+
       await reconnected;
     } finally {
       closeWindow();

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import { type HarnessSession, type HarnessRunState } from './harness-session.js';
 import { runHarnessTestFile } from './run.js';
+import { resolveResetStrategyKind } from './environment-reset.js';
 import {
   NativeCrashError,
   RuntimeDisconnectError,
@@ -189,7 +190,9 @@ export const executeRun = async (
     host: session.config.host?.trim() || undefined,
   });
 
-  const shouldResetEnv = session.config.resetEnvironmentBetweenTestFiles;
+  const resetStrategyKind = resolveResetStrategyKind(
+    session.config.resetEnvironmentBetweenTestFiles,
+  );
   const platformId = session.context.platform.platformId;
   const knownPlatformIds = new Set(
     session.config.runners.map((runner) => runner.platformId),
@@ -257,9 +260,13 @@ export const executeRun = async (
         }
 
         try {
-          if ((shouldResetEnv && !isFirstTest) || shouldRestartAfterTimeout) {
+          if (shouldRestartAfterTimeout) {
+            // Recovery from a runtime timeout always uses the (stronger)
+            // process restart, never the configured reset strategy.
             await session.restartApp(test.path);
             shouldRestartAfterTimeout = false;
+          } else if (resetStrategyKind !== null && !isFirstTest) {
+            await session.resetEnvironment(test.path);
           }
           isFirstTest = false;
 

--- a/packages/jest/src/harness-session.ts
+++ b/packages/jest/src/harness-session.ts
@@ -54,6 +54,12 @@ import path from 'node:path';
 import { PlatformReadyTimeoutError } from './errors.js';
 import { NoRunnerSpecifiedError, RunnerNotFoundError } from './errors.js';
 import { createCrashMonitor, type CrashMonitor } from './crash-monitor.js';
+import {
+  createProcessResetStrategy,
+  createRuntimeResetStrategy,
+  resolveResetStrategyKind,
+  withEscalation,
+} from './environment-reset.js';
 import { createHookQueue, type HookQueue } from './hook-queue.js';
 import {
   createClientLogCollector,
@@ -125,6 +131,28 @@ export const waitForBridgeDisconnectOrTimeout = async ({
   });
 };
 
+// Resolves the NEXT time the bridge reports a 'connected' event, rejecting
+// if `signal` aborts first. Deliberately does not use bridge.nextConnection(),
+// which would resolve immediately for a stale, already-set connection.
+export const waitForNextConnected = ({
+  bridge,
+  signal,
+}: {
+  bridge: Pick<HarnessBridge, 'on' | 'off'>;
+  signal: AbortSignal;
+}): Promise<void> =>
+  new Promise<void>((resolve, reject) => {
+    const onConnected = () => { cleanup(); resolve(); };
+    const onAbort = () => { cleanup(); reject(signal.reason ?? new DOMException('Aborted', 'AbortError')); };
+    const cleanup = () => {
+      bridge.off('connected', onConnected);
+      signal.removeEventListener('abort', onAbort);
+    };
+    if (signal.aborted) { onAbort(); return; }
+    bridge.on('connected', onConnected);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
 export type HarnessRunState = {
   readonly runId: string;
   readonly startTime: number;
@@ -147,6 +175,7 @@ export type HarnessSession = {
   runTestFile: (path: string, options: HarnessRunTestsOptions) => Promise<TestSuiteResult>;
   ensureAppReady: (testFilePath: string) => Promise<void>;
   restartApp: (testFilePath?: string) => Promise<void>;
+  resetEnvironment: (testFilePath: string) => Promise<void>;
   resetCrashState: () => void;
   flushClientLogs: () => ClientLogBuffer;
   callHook: HarnessPluginManager<HarnessConfig, HarnessPlatform>['callHook'];
@@ -285,17 +314,7 @@ const waitForAppReady = async (
       // is already set. waitForReady is called before startAttempt, so a stale
       // connection from a previous run would resolve the promise before startAttempt
       // even restarts the app — leaving bridge.connection null after the restart.
-      await new Promise<void>((resolve, reject) => {
-        const onConnected = () => { cleanup(); resolve(); };
-        const onAbort = () => { cleanup(); reject(signal.reason ?? new DOMException('Aborted', 'AbortError')); };
-        const cleanup = () => {
-          bridge.off('connected', onConnected);
-          signal.removeEventListener('abort', onAbort);
-        };
-        if (signal.aborted) { onAbort(); return; }
-        bridge.on('connected', onConnected);
-        signal.addEventListener('abort', onAbort, { once: true });
-      });
+      await waitForNextConnected({ bridge, signal });
       logWait('runtime ready received');
     },
     waitForCrash: async (signal) => {
@@ -868,9 +887,26 @@ export const createHarnessSession = async (
       appReadySpan.end({ file: testFilePath, reused: false });
     };
 
+    // Shared by restartApp (crash/timeout recovery) and the 'process' reset
+    // strategy: kill the current app session and either wait for a fresh one
+    // to become ready for testFilePath, or (no testFilePath) just launch one.
+    const performRestart = async (testFilePath?: string): Promise<void> => {
+      await crashMonitor.stop();
+      await disposeCurrentAppSession();
+
+      if (testFilePath) {
+        await ensureAppReady(testFilePath);
+      } else {
+        const session = await platformInstance.createAppSession(appLaunchOptions);
+        currentAppSession = session;
+        crashMonitor.setAppSession(session);
+        crashMonitor.reset();
+        await crashMonitor.start();
+      }
+    };
+
     const restartApp = async (testFilePath?: string): Promise<void> => {
       await hooks.drain();
-      await crashMonitor.stop();
       const reason: 'stop-and-ensure-ready' | 'direct-restart' = testFilePath
         ? 'stop-and-ensure-ready'
         : 'direct-restart';
@@ -882,23 +918,64 @@ export const createHarnessSession = async (
       const restartSpan = diagnostics.start('app.restart', { reason });
 
       try {
-        await disposeCurrentAppSession();
-
-        if (testFilePath) {
-          await ensureAppReady(testFilePath);
-        } else {
-          const session = await platformInstance.createAppSession(appLaunchOptions);
-          currentAppSession = session;
-          crashMonitor.setAppSession(session);
-          crashMonitor.reset();
-          await crashMonitor.start();
-        }
-
+        await performRestart(testFilePath);
         await hooks.drain();
         sessionLogger.debug('restart completed');
         restartSpan.end();
       } catch (error) {
         restartSpan.fail(error);
+        throw error;
+      }
+    };
+
+    const processResetStrategy = createProcessResetStrategy({
+      restart: performRestart,
+    });
+    const runtimeResetStrategy = createRuntimeResetStrategy({
+      getConnection: () => bridge.connection,
+      expectDisconnect: crashMonitor.expectDisconnect,
+      waitForReconnect: (signal) => waitForNextConnected({ bridge, signal }),
+      timeoutMs: runtimeConfig.bundleStartTimeout ?? 60000,
+    });
+
+    const resetEnvironment = async (testFilePath: string): Promise<void> => {
+      const requestedKind = resolveResetStrategyKind(
+        runtimeConfig.resetEnvironmentBetweenTestFiles,
+      );
+      if (requestedKind === null) {
+        return;
+      }
+
+      await hooks.drain();
+      sessionLogger.debug(
+        'resetting environment (testFile=%s kind=%s)',
+        testFilePath,
+        requestedKind,
+      );
+
+      let escalated = false;
+      const strategy = requestedKind === 'runtime'
+        ? withEscalation(runtimeResetStrategy, processResetStrategy, {
+            onEscalate: (error) => {
+              escalated = true;
+              sessionLogger.debug(
+                'runtime reset failed, escalating to process restart: %s',
+                error,
+              );
+            },
+          })
+        : processResetStrategy;
+
+      const resetSpan = diagnostics.start('app.reset', { requested: requestedKind });
+      const performed = () => (escalated ? 'process' : requestedKind);
+
+      try {
+        await strategy.reset({ testFilePath });
+        await hooks.drain();
+        sessionLogger.debug('environment reset completed');
+        resetSpan.end({ performed: performed(), escalated });
+      } catch (error) {
+        resetSpan.fail(error, { performed: performed(), escalated });
         throw error;
       }
     };
@@ -966,6 +1043,7 @@ export const createHarnessSession = async (
       runTestFile,
       ensureAppReady,
       restartApp,
+      resetEnvironment,
       resetCrashState: () => crashMonitor.reset(),
       flushClientLogs,
       callHook: async (name, payload) => {

--- a/packages/jest/src/harness-session.ts
+++ b/packages/jest/src/harness-session.ts
@@ -1,5 +1,6 @@
 import {
   createHarnessBridge,
+  AppBridgeDisconnectedError,
   type HarnessBridge,
   type AppConnection,
 } from '@react-native-harness/bridge/server';
@@ -935,6 +936,9 @@ export const createHarnessSession = async (
       getConnection: () => bridge.connection,
       expectDisconnect: crashMonitor.expectDisconnect,
       waitForReconnect: (signal) => waitForNextConnected({ bridge, signal }),
+      // Pending rpc.invoke calls reject with AppBridgeDisconnectedError when
+      // the app connection drops (see bridge server's disconnect()).
+      isDisconnectError: (error) => error instanceof AppBridgeDisconnectedError,
       timeoutMs: runtimeConfig.bundleStartTimeout ?? 60000,
     });
 

--- a/packages/runtime/src/client/factory.ts
+++ b/packages/runtime/src/client/factory.ts
@@ -1,3 +1,4 @@
+import { DevSettings, Platform } from 'react-native';
 import type {
   TestRunnerEvents,
   TestCollectorEvents,
@@ -20,8 +21,24 @@ import { runSetupFiles } from './setup-files.js';
 import { setHandle } from './store.js';
 import { installPromiseTracker } from '../promise-tracker.js';
 
+// Reloading tears down the JS runtime, so the RPC caller would never see a
+// response if we reloaded synchronously. Acknowledge first, then reload on
+// the next tick so the response has a chance to flush over the bridge.
+const reloadRuntime = (): void => {
+  setTimeout(() => {
+    if (Platform.OS === 'web') {
+      window.location.reload();
+    } else {
+      DevSettings.reload();
+    }
+  }, 100);
+};
+
 export const getClient = async (): Promise<HarnessHandle> => {
   const handle = await connectToHarness(getWSServer(), {
+    resetEnvironment: async () => {
+      reloadRuntime();
+    },
     runTests: async (path: string, options: TestExecutionOptions) => {
       installPromiseTracker();
 

--- a/packages/runtime/src/client/factory.ts
+++ b/packages/runtime/src/client/factory.ts
@@ -1,4 +1,4 @@
-import { DevSettings, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import type {
   TestRunnerEvents,
   TestCollectorEvents,
@@ -29,6 +29,9 @@ const reloadRuntime = (): void => {
     if (Platform.OS === 'web') {
       window.location.reload();
     } else {
+      // Required lazily: react-native-web doesn't export DevSettings, so a
+      // named import would be undefined on web. Only native reaches this.
+      const { DevSettings } = require('react-native');
       DevSettings.reload();
     }
   }, 100);

--- a/website/src/docs/api/test-environment.mdx
+++ b/website/src/docs/api/test-environment.mdx
@@ -76,7 +76,17 @@ mock('react-native-safe-area-context', () => ({
 
 By default, Harness ensures test isolation by resetting the environment between test files.
 
-- **`resetEnvironmentBetweenTestFiles`**: (Default: `true`) When enabled, the app is fully restarted between different test files. This prevents state leakage (like singleton native modules or global variables) from affecting subsequent tests.
+- **`resetEnvironmentBetweenTestFiles`**: (Default: `true`) Controls how — or whether — the environment is reset between test files. Accepts a boolean or one of two strategy names:
+  - **`true` / `'process'`** (default): The app process is fully killed and relaunched between test files. This prevents state leakage (like singleton native modules or global variables) from affecting subsequent tests, at the cost of a full app restart per file.
+  - **`'runtime'`**: Instead of restarting the process, Harness reloads the JS runtime in place (`DevSettings.reload()` on native, `window.location.reload()` on web). This resets the JS runtime, TurboModule instances, and Fabric state without paying for a process restart, which is significantly faster. If the reload fails, doesn't acknowledge, or the app doesn't reconnect in time, Harness automatically escalates to a full `'process'` restart for that file so the run doesn't hang or leave the app in an inconsistent state.
+  - **`false`**: The environment is never reset between test files. Use this only if you manage isolation yourself.
+
+  ```javascript title="rn-harness.config.mjs"
+  const config = {
+    // ...
+    resetEnvironmentBetweenTestFiles: 'runtime',
+  };
+  ```
 
 ### Native Module Mocking
 

--- a/website/src/docs/getting-started/configuration.mdx
+++ b/website/src/docs/getting-started/configuration.mdx
@@ -103,7 +103,7 @@ For Expo projects, the `entryPoint` should be set to the path specified in the `
 | `maxAppRestarts`                   | Maximum number of automatic app relaunch attempts while Harness is waiting for startup (default: `2`).                                                    |
 | `eagerPrewarm`                     | Start building the Metro bundle while the platform is still booting so the first bundle is ready sooner (default: `true`).                                |
 | `permissions`                      | Enable platform-specific permission prompt automation (default: `false`). On iOS, this controls whether Harness starts the XCTest-based permission helper. |
-| `resetEnvironmentBetweenTestFiles` | Reset environment between test files (default: `true`).                                                                                                   |
+| `resetEnvironmentBetweenTestFiles` | How to reset the environment between test files: `true`/`'process'` restarts the app process (default), `'runtime'` reloads the JS runtime in place (falling back to a process restart on failure), `false` disables resetting. |
 | `detectNativeCrashes`              | Detect native app crashes during startup and test execution (default: `true`).                                                                            |
 | `crashDetectionInterval`           | Interval in milliseconds to check for native crashes (default: `500`).                                                                                    |
 | `disableViewFlattening`            | Disable view flattening in React Native (default: `false`).                                                                                               |


### PR DESCRIPTION
## What is this?

This PR makes the environment reset between test files configurable, adding a `'runtime'` strategy that reloads the React instance in place instead of killing and cold-restarting the app process.

Diagnostics traces show that full process restarts dominate Harness runs: on the Android playground suite, 17 restarts account for 60–68% of total wall time (~7.4s each — adb commands, native app boot, and re-downloading and re-evaluating the same entry bundle every time). Most of that work exists only to reset state between files, and a React instance reload achieves the same reset for everything scoped to the React lifecycle at a fraction of the cost.

`resetEnvironmentBetweenTestFiles` now accepts:

- `true` / `'process'` (default, unchanged): kill and relaunch the app process.
- `'runtime'`: reload the JS runtime in place — `DevSettings.reload()` on native, `window.location.reload()` on web.
- `false` (unchanged): never reset.

## How does it work?

Both strategies sit behind a single `EnvironmentResetStrategy` interface with one post-condition: bridge connected, runtime ready, crash-monitor state consistent. The session builds the configured strategy and exposes it as `session.resetEnvironment(testFilePath)`, which `execute-run` calls between files.

The `'runtime'` strategy works as follows:

1. The server opens an *expected-disconnect window* on the crash monitor, so the intentional bridge drop isn't misclassified as a native crash.
2. It invokes a new `resetEnvironment` RPC on the app connection. The runtime acknowledges first, then triggers the reload on a short delay so the response flushes before the runtime dies. A disconnect-flavored RPC rejection (the ack losing that race) is treated as reload-in-flight, not failure.
3. It waits for the bridge's next `connected` event, bounded by `bundleStartTimeout`.

If anything goes wrong — no active connection, RPC failure, reconnect timeout — an escalation decorator falls back to a full `'process'` restart for that file, so a failed reload degrades to today's behavior instead of hanging or corrupting the run. Crash/timeout recovery (`restartApp`) remains hard-wired to the process restart and never uses the weaker strategy; both paths share one restart implementation.

Each between-files reset emits an `app.reset` diagnostics span with `{ requested, performed, escalated }`, so escalation rates are directly visible in traces.

A React instance reload tears down the whole JS VM, TurboModule instances, and Fabric state — the delta versus a process restart is only process-global native state (statics, application-scoped singletons), which is why `'process'` remains available and the default.

## Why is this useful?

- **Significantly faster runs**: an in-place reload skips the adb churn, native process boot, and much of the per-file overhead of a cold start. Validated end-to-end on the playground web suite: 18/18 files pass with `'runtime'`, 17 resets totaling 2.9s (max 184ms each, zero escalations) — versus a full browser relaunch per file before.
- **Safe to adopt**: automatic escalation to a process restart means the worst case for an incompatible platform or a wedged runtime is one slower file, not a broken run — and escalations are observable in diagnostics.
- **No breaking changes**: existing boolean configs behave exactly as before; the default stays `'process'`.
- **Extensible seam**: the strategy interface isolates reset behavior behind one contract, keeping recovery semantics, crash detection, and the test loop untouched.
