### PR TITLE
Destroy lingering sockets when disposing the Metro server

### DIFF
--- a/.nx/version-plans/fix-metro-dispose-lingering-sockets.md
+++ b/.nx/version-plans/fix-metro-dispose-lingering-sockets.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fixes a hang where the harness process never exits after tests finish, most common on Android and occasional on iOS. A stray WebSocket connection to Metro's dev server (e.g. a half-open HMR client) could prevent the server from shutting down, leaving Jest running indefinitely until it was killed manually or by a CI timeout. Metro now force-closes any lingering connections when the harness tears down, so runs terminate reliably and Ctrl+C/SIGTERM work as expected.

--- a/packages/bundler-metro/src/factory.ts
+++ b/packages/bundler-metro/src/factory.ts
@@ -1,6 +1,7 @@
 import { logger, withAbortTimeout } from '@react-native-harness/tools';
 import type { Server as HttpServer } from 'node:http';
 import type { Server as HttpsServer } from 'node:https';
+import type { Socket } from 'node:net';
 import connect from 'connect';
 import nocache from 'nocache';
 import { isPortAvailable, getMetroPackage } from './utils.js';
@@ -152,6 +153,15 @@ export const getMetroInstance = async (
     'httpServer' in maybeServer ? maybeServer.httpServer : maybeServer;
   server.keepAliveTimeout = 30000;
 
+  // closeAllConnections() does not close sockets upgraded to WebSockets (e.g. Metro's /hot
+  // endpoint), but those sockets block server.close() from ever firing its callback; track them
+  // so dispose() can force-destroy whatever remains.
+  const sockets = new Set<Socket>();
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+
   abortSignal.throwIfAborted();
 
   await ready;
@@ -256,6 +266,9 @@ export const getMetroInstance = async (
         reporter.removeListener(onBuildEvent);
         server.close(() => resolve());
         server.closeAllConnections();
+        for (const socket of sockets) {
+          socket.destroy();
+        }
       }),
   };
 };


### PR DESCRIPTION
## What is this?

This PR fixes runs where the harness process never exits after tests complete. All test results and diagnostics are printed, but the Node process stays alive indefinitely and has to be killed manually (or by a CI timeout). The hang is intermittent and shows up mostly on Android, occasionally on iOS.

## How does it work?

The Metro instance's `dispose()` resolves from the `server.close()` callback and calls `server.closeAllConnections()` to sever remaining clients. However, on Node (verified on v24.14), `closeAllConnections()` does **not** destroy sockets that have been upgraded to WebSockets — such as clients of Metro's internal `/hot` HMR endpoint — while those same sockets still block `server.close()` from ever completing.

On Android the app reaches Metro through `adb reverse`, so the host side of the `/hot` connection is owned by the adb server. When the app is force-stopped during teardown, adb usually closes that socket promptly — but sometimes leaves it half-open. When that happens, `dispose()` never resolves, session teardown never finishes, and the Jest process idles forever. Metro 0.83 also shuts down its transformer worker farm and file watcher only in the HTTP server's `close` event, so those handles stayed alive too.

The fix tracks every TCP connection accepted by the Metro HTTP server in a `Set` (deregistered on socket close) and force-destroys whatever remains during `dispose()`. This guarantees the `close` event fires, Metro tears down its internals, and the process can exit.

Verified with a deterministic repro: a stray WebSocket client holding `/hot` open during an Android run. Without the fix the process hangs after the test summary until SIGKILL; with the fix the same run force-closes the stray socket and exits cleanly with code 0.

## Why is this useful?

- Harness runs terminate reliably — no more zombie processes lingering after tests pass, locally or in CI.
- Ctrl+C / SIGTERM works again in the affected state (previously the signal handler awaited the already-stuck dispose, so even graceful termination was impossible).
- Removes a whole class of flakiness for any client that keeps a WebSocket to the Metro port open at teardown time (HMR clients, DevTools, half-open adb sockets).