### PR TITLE
Fix Harness process lingering after tests when diagnostics are enabled

### DIFF
--- a/.nx/version-plans/fix-diagnostics-lingering-process.md
+++ b/.nx/version-plans/fix-diagnostics-lingering-process.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fixes a hang where the harness process kept running after tests finished whenever diagnostics were enabled (via the `diagnostics` config option or `RN_HARNESS_DIAGNOSTICS`). Diagnostics instrumentation replaced subprocess handles returned by adb/simctl with plain promises, so teardown could no longer kill the background `adb logcat` / app-launch processes and they kept the harness alive. Instrumented calls now return the original subprocess handles untouched, so runs with diagnostics enabled terminate cleanly.

--- a/packages/tools/src/__tests__/diagnostics.test.ts
+++ b/packages/tools/src/__tests__/diagnostics.test.ts
@@ -231,6 +231,35 @@ describe('instrumented()', () => {
     expect(listeners.size).toBe(0);
   });
 
+  it('returns hybrid thenables (e.g. nano-spawn Subprocess) untouched, not collapsed to a plain Promise', async () => {
+    const diagnostics = createDiagnostics({ enabled: true });
+    const nodeChildProcess = Promise.resolve({ kill: vi.fn() });
+    const hybrid = Object.assign(Promise.resolve('done'), {
+      nodeChildProcess,
+      [Symbol.asyncIterator]: async function* () {
+        yield 'line-1';
+      },
+    });
+    const target = { startLogcat: () => hybrid };
+
+    const wrapped = instrumented(target, 'platform.android.adb', diagnostics);
+    const result = wrapped.startLogcat();
+
+    expect(result).toBe(hybrid);
+    expect((result as typeof hybrid).nodeChildProcess).toBe(nodeChildProcess);
+
+    const lines: string[] = [];
+    for await (const line of result as AsyncIterable<string>) {
+      lines.push(line);
+    }
+    expect(lines).toEqual(['line-1']);
+
+    await wait(5);
+    const entries = diagnostics.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.status).toBe('ok');
+  });
+
   it('spy-based check that fn is invoked once per call', () => {
     const diagnostics = createDiagnostics({ enabled: true });
     const spy = vi.fn(() => 'ok');

--- a/packages/tools/src/diagnostics.ts
+++ b/packages/tools/src/diagnostics.ts
@@ -258,16 +258,17 @@ export const instrumented = <T extends object>(
           'then' in result &&
           typeof (result as { then: unknown }).then === 'function'
         ) {
-          return (result as Promise<unknown>).then(
-            (resolved) => {
-              span.end();
-              return resolved;
-            },
-            (error: unknown) => {
-              span.fail(error);
-              throw error;
-            }
+          // Some thenables (e.g. nano-spawn's Subprocess) carry extra
+          // properties/behavior beyond `.then()` (async iteration, a handle
+          // to the underlying child process, etc). Calling `.then()` and
+          // returning its result would collapse them into a plain Promise
+          // and silently drop that shape, so track the span as a side
+          // effect and always return the original object untouched.
+          (result as Promise<unknown>).then(
+            () => span.end(),
+            (error: unknown) => span.fail(error)
           );
+          return result;
         }
 
         span.end();


### PR DESCRIPTION
## What is this?

This PR fixes a hang where the Harness process kept running after all tests finished whenever diagnostics were enabled (via the `diagnostics` config option or the `RN_HARNESS_DIAGNOSTICS` env var). Runs with diagnostics off exited cleanly; the same runs with diagnostics on lingered until killed manually or by a CI timeout.

## How does it work?

When diagnostics are enabled, platform modules like adb and simctl are wrapped with the `instrumented()` proxy to record timing spans. The wrapper treated every thenable result as an ordinary promise and returned `result.then(...)` — but calling `.then()` on a thenable always produces a brand-new plain `Promise`, discarding any extra shape the original object had.

That's fatal for nano-spawn's `Subprocess` return value (used by `adb.startLogcat` and `simctl.launchAppProcess`), which is a promise *plus* `nodeChildProcess` and `Symbol.asyncIterator`. With those stripped, teardown's `stopSubprocess()` found `nodeChildProcess === undefined`, the kill attempt threw into an intentionally silent catch, and the background `adb logcat` / app-launch OS processes survived — keeping Node's event loop alive after the run finished. Log streaming via `for await` over the subprocess broke the same way.

The wrapper now records span completion as a side-effect `.then()` and always returns the original thenable untouched, so subprocess handles (and any other hybrid thenables) pass through instrumentation with their shape intact. A regression test covers the hybrid-thenable case, and a version plan is included.

## Why is this useful?

- Harness runs with diagnostics enabled now terminate cleanly instead of hanging until a manual kill or CI timeout, so diagnostics can be left on in CI without risk.
- Background `adb logcat` and app-launch subprocesses are reliably killed during teardown, so log streaming and crash detection behave identically with and without diagnostics.
- Instrumentation is now shape-preserving by construction, preventing the same silent-stripping bug for any future API that returns an augmented promise.
