### PR TITLE
Reduce XCTest permission watchdog CPU usage and make its polling interval tunable

### DIFF
--- a/.nx/version-plans/cut-xctest-permission-watchdog-polling.md
+++ b/.nx/version-plans/cut-xctest-permission-watchdog-polling.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+The iOS permission-dialog watchdog now uses far less CPU, and its polling interval is tunable via HARNESS_XCTEST_AGENT_TICK_INTERVAL_MS.

--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -116,6 +116,7 @@ export default {
   defaultRunner: 'android',
   platformReadyTimeout: 300000,
   bridgeTimeout: 120000,
+  testTimeout: 10000,
 
   permissions: true,
   detectNativeCrashes: true,

--- a/packages/platform-ios/src/xctest-agent.ts
+++ b/packages/platform-ios/src/xctest-agent.ts
@@ -25,6 +25,8 @@ const xctestAgentLogger = logger.child('ios-xctest-agent');
 const XCTEST_AGENT_PROJECT_NAME = 'HarnessXCTestAgent';
 const XCTEST_AGENT_SCHEME_NAME = 'HarnessXCTestAgent';
 const XCTEST_AGENT_PORT_ENV = 'HARNESS_XCTEST_AGENT_PORT';
+const XCTEST_AGENT_TICK_INTERVAL_MS_ENV =
+  'HARNESS_XCTEST_AGENT_TICK_INTERVAL_MS';
 const XCTEST_AGENT_TARGET_BUNDLE_ID_ENV =
   'HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID';
 const XCTEST_AGENT_XCTESTRUN_FILE_ENV = 'HARNESS_IOS_XCTESTRUN_FILE';
@@ -937,11 +939,18 @@ export const createXCTestAgentController = (options: {
   let processTask: Promise<void> | null = null;
 
   const getLaunchEnvironment = (): Record<string, string> => {
+    const tickIntervalMs = getEnvironmentPath(XCTEST_AGENT_TICK_INTERVAL_MS_ENV);
+
     return Object.assign(
       {},
       options.appBundleId
         ? {
             [XCTEST_AGENT_TARGET_BUNDLE_ID_ENV]: options.appBundleId,
+          }
+        : {},
+      tickIntervalMs
+        ? {
+            [XCTEST_AGENT_TICK_INTERVAL_MS_ENV]: tickIntervalMs,
           }
         : {},
       ...capabilities.map(

--- a/packages/platform-ios/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
+++ b/packages/platform-ios/xctest-agent/HarnessXCTestAgentUITests/HarnessXCTestAgentUITests.swift
@@ -180,11 +180,24 @@ private final class XCTestAgentHTTPServer {
 final class HarnessXCTestAgentUITests: XCTestCase {
   private enum Environment {
     static let targetBundleIdentifier = "HARNESS_XCTEST_AGENT_TARGET_BUNDLE_ID"
+    static let tickIntervalMs = "HARNESS_XCTEST_AGENT_TICK_INTERVAL_MS"
   }
 
   private enum Constants {
     static let defaultSessionDuration: TimeInterval = 60 * 60
-    static let tickInterval: TimeInterval = 1
+    static let defaultTickInterval: TimeInterval = 1
+  }
+
+  private static func resolveTickInterval() -> TimeInterval {
+    guard
+      let rawValue = ProcessInfo.processInfo.environment[Environment.tickIntervalMs],
+      let milliseconds = Int(rawValue),
+      milliseconds > 0
+    else {
+      return Constants.defaultTickInterval
+    }
+
+    return TimeInterval(milliseconds) / 1000
   }
 
   private let state = HarnessXCTestAgentState(
@@ -194,6 +207,7 @@ final class HarnessXCTestAgentUITests: XCTestCase {
   private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
   private var capabilities: [AgentCapability] = []
   private var httpServer: XCTestAgentHTTPServer?
+  private let tickInterval = HarnessXCTestAgentUITests.resolveTickInterval()
 
   private func log(_ message: String) {
     NSLog("[HarnessXCTestAgent] %@", message)
@@ -309,7 +323,7 @@ final class HarnessXCTestAgentUITests: XCTestCase {
       }
 
       RunLoop.current.run(
-        until: Date().addingTimeInterval(Constants.tickInterval)
+        until: Date().addingTimeInterval(tickInterval)
       )
     }
 

--- a/packages/platform-ios/xctest-agent/HarnessXCTestAgentUITests/PermissionPromptWatchdog.swift
+++ b/packages/platform-ios/xctest-agent/HarnessXCTestAgentUITests/PermissionPromptWatchdog.swift
@@ -54,6 +54,14 @@ final class PermissionPromptWatchdog: AgentCapability {
       return
     }
 
+    let guardQuery = springboard.buttons.matching(
+      NSPredicate(format: "label IN %@", Constants.knownPositiveButtonLabels)
+    ).firstMatch
+
+    guard guardQuery.exists else {
+      return
+    }
+
     for label in Constants.knownPositiveButtonLabels {
       let button = springboard.buttons[label].firstMatch
 


### PR DESCRIPTION
## What is this?

This PR sharply reduces the CPU cost of the iOS permission-dialog watchdog that runs inside the XCTest agent when `permissions` is enabled. Previously, every watchdog tick evaluated 11 known button labels against SpringBoard, and each evaluation triggered a separate cross-process accessibility snapshot — roughly one snapshot every 100 ms, continuously, for the whole session. On busy CI runners (notably `macos-26-arm64`) this kept the agent, `testmanagerd`, and SpringBoard permanently busy and degraded overall test performance. It also makes the watchdog's polling interval tunable without rebuilding the agent.

## How does it work?

The watchdog's idle path now costs a single accessibility snapshot per tick: one query matches SpringBoard buttons against the full set of known permission-button labels with a `label IN {…}` predicate. Only when that guard matches — meaning a permission dialog is actually on screen — does the watchdog fall back to the existing priority-ordered label loop, so tap selection on multi-button dialogs (for example preferring "While Using the App" over "Allow Once") behaves exactly as before.

The tick interval keeps its 1-second default so permission dialogs are still accepted quickly enough for tight test timeouts, but it can now be overridden through the `HARNESS_XCTEST_AGENT_TICK_INTERVAL_MS` environment variable: the harness forwards it from its own environment into the agent's launch environment, and the agent falls back to the default when the value is unset or invalid. Combined with the single-snapshot guard, idle snapshot volume drops from ~11 per second to ~1 per second.

## Why is this useful?

- iOS test runs with `permissions` enabled no longer pay a constant CPU tax for the whole session, which directly improves test performance and stability on CI runners.
- Permission auto-acceptance behaves identically — the same dialogs are detected and the same buttons are tapped.
- CI environments can tune the polling cadence via an environment variable without rebuilding the XCTest agent.

The branch also carries the playground `testTimeout` raise to 10 s (cherry-picked), since slow CI UI interactions on `macos-26-arm64` runners were already hitting the previous 5 s budget independently of the watchdog.
