### PR TITLE
fix(platform-ios): clear graceful shutdown timer

### DIFF
--- a/.nx/version-plans/version-plan-1784624669908.md
+++ b/.nx/version-plans/version-plan-1784624669908.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+iOS Harness runs now end cleanly after XCTest-agent shutdown instead of lingering for the shutdown timeout.

--- a/packages/platform-ios/src/__tests__/xctest-agent.test.ts
+++ b/packages/platform-ios/src/__tests__/xctest-agent.test.ts
@@ -514,6 +514,30 @@ describe('xctest-agent orchestration', () => {
     expect(mocks.kill).not.toHaveBeenCalled();
   });
 
+  it('clears the shutdown timer after graceful shutdown', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const controller = createXCTestAgentController({
+        port: 49154,
+        shutdownTimeoutMs: 30_000,
+        target: {
+          kind: 'simulator',
+          id: 'sim-timeout',
+        },
+      });
+
+      await controller.ensureStarted();
+      await controller.dispose();
+
+      expect(mocks.shutdown).toHaveBeenCalledTimes(1);
+      expect(mocks.kill).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('kills the agent process when graceful shutdown times out', async () => {
     mocks.shutdown.mockResolvedValue(undefined);
 

--- a/packages/platform-ios/src/xctest-agent.ts
+++ b/packages/platform-ios/src/xctest-agent.ts
@@ -762,51 +762,45 @@ const waitForAgentReady = async (options: {
   );
 };
 
-const waitForShutdown = async (options: {
-  processTask: Promise<void> | null;
-  shutdownTimeoutMs: number;
-}): Promise<boolean> => {
-  if (!options.processTask) {
-    return true;
-  }
-
-  const timedOut = Symbol('timedOut');
-  const result = await Promise.race([
-    options.processTask.then(() => undefined),
-    delay(options.shutdownTimeoutMs).then(() => timedOut),
-  ]);
-
-  return result !== timedOut;
-};
-
 const waitForGracefulShutdown = async (options: {
   client: ReturnType<typeof createXCTestAgentClient>;
   processTask: Promise<void> | null;
   shutdownTimeoutMs: number;
 }): Promise<{ didStop: boolean; requestError: unknown | null }> => {
   let requestError: unknown | null = null;
+  let shutdownTimer: ReturnType<typeof setTimeout> | null = null;
   const timedOut = Symbol('timedOut');
+  const timeoutTask = new Promise<typeof timedOut>((resolve) => {
+    shutdownTimer = setTimeout(
+      () => resolve(timedOut),
+      options.shutdownTimeoutMs
+    );
+  });
 
-  const result = await Promise.race([
-    (async () => {
-      try {
-        await options.client.shutdown();
-      } catch (error) {
-        requestError = error;
-      }
+  try {
+    const result = await Promise.race([
+      (async () => {
+        try {
+          await options.client.shutdown();
+        } catch (error) {
+          requestError = error;
+        }
 
-      return await waitForShutdown({
-        processTask: options.processTask,
-        shutdownTimeoutMs: options.shutdownTimeoutMs,
-      });
-    })(),
-    delay(options.shutdownTimeoutMs).then(() => timedOut),
-  ]);
+        await options.processTask;
+        return true;
+      })(),
+      timeoutTask,
+    ]);
 
-  return {
-    didStop: result !== timedOut && result === true,
-    requestError,
-  };
+    return {
+      didStop: result !== timedOut,
+      requestError,
+    };
+  } finally {
+    if (shutdownTimer !== null) {
+      clearTimeout(shutdownTimer);
+    }
+  }
 };
 
 const waitForChildProcessExit = async (subprocess: Subprocess) => {


### PR DESCRIPTION
## What is this?

This PR fixes iOS Harness test runs lingering for roughly 30 seconds after the XCTest agent has already shut down successfully. The graceful-shutdown path used nested `Promise.race` calls with referenced timeout promises; when the protocol shutdown and `xcodebuild` exit won those races, the losing timers remained active until their 30-second deadlines.

## How does it work?

The platform-iOS shutdown path now owns one local cancellable timeout and clears it in `finally` whenever the race settles. The change stays local to the package—no shared utility is extracted—and preserves the existing sequence: request `client.shutdown()`, wait for the `xcodebuild` process task to exit, then use the shared `terminate()` helper only as fallback.

A fake-timer regression test verifies that successful protocol shutdown invokes the shutdown request, avoids process termination, and leaves no active timer. Validation covered a forced platform-Apple build with dependencies, platform-Apple typechecking and linting, the full platform-iOS suite (60 tests across 11 files), and the focused XCTest-agent suite (18 tests); commit and push hooks also passed their affected-project typecheck, lint, and build checks.

## Why is this useful?

Successful iOS test runs can exit promptly instead of waiting for a stale 30-second timer, while retaining graceful XCTest/`xcodebuild` teardown and the established SIGTERM/SIGKILL fallback for genuine shutdown failures.
