### PR TITLE
fix(cli): bundle supported Jest CLI runtime

### DIFF
--- a/.nx/version-plans/version-plan-1784628278546.md
+++ b/.nx/version-plans/version-plan-1784628278546.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness commands now include the supported Jest CLI runtime, so the init command works when invoked through yarn dlx or npx.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,16 +25,13 @@
     "@react-native-harness/config": "workspace:*",
     "@react-native-harness/platforms": "workspace:*",
     "@react-native-harness/tools": "workspace:*",
+    "jest-cli": "^30.2.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "jest-cli": "^30.2.0",
     "@react-native-harness/platform-android": "workspace:*",
     "@react-native-harness/platform-apple": "workspace:*",
     "@react-native-harness/platform-web": "workspace:*"
-  },
-  "peerDependencies": {
-    "jest-cli": "*"
   },
   "license": "MIT"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@react-native-harness/tools':
         specifier: workspace:*
         version: link:../tools
+      jest-cli:
+        specifier: ^30.2.0
+        version: 30.2.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -340,9 +343,6 @@ importers:
       '@react-native-harness/platform-web':
         specifier: workspace:*
         version: link:../platform-web
-      jest-cli:
-        specifier: ^30.2.0
-        version: 30.2.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)
 
   packages/config:
     dependencies:


### PR DESCRIPTION
## What is this?

Harness now ships the Jest CLI version it supports instead of relying on a consumer-installed peer. This fixes standalone CLI invocations such as yarn dlx react-native-harness init.

## How does it work?

The CLI declares jest-cli 30.2 as a runtime dependency, aligned with Harness’s existing Jest 30 integration. Package managers can still deduplicate it when a compatible version is already present.

## Why is this useful?

Harness commands use a known-compatible Jest runtime in both existing projects and temporary package-manager environments, avoiding missing-peer startup failures.