### PR TITLE
perf(platform-ios): overlap XCTest agent build with simulator boot

### DIFF
--- a/.nx/version-plans/overlap-ios-xctest-agent-build-with-simulator-boot.md
+++ b/.nx/version-plans/overlap-ios-xctest-agent-build-with-simulator-boot.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+The iOS XCTest permission agent now starts building while the simulator boots instead of waiting for the boot to finish first, cutting startup time for simulator runs that need permission auto-acceptance—especially on a cold build cache.

--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -114,7 +114,7 @@ export default {
     }),
   ],
   defaultRunner: 'android',
-  platformReadyTimeout: 300000,
+  platformReadyTimeout: 480000,
   bridgeTimeout: 120000,
   testTimeout: 10000,
 

--- a/packages/platform-ios/src/__tests__/instance-xctest-agent.test.ts
+++ b/packages/platform-ios/src/__tests__/instance-xctest-agent.test.ts
@@ -85,8 +85,11 @@ describe('iOS XCTest agent runner integration', () => {
       },
       signal: initSignal,
     });
-    expect(mocks.prepare).not.toHaveBeenCalled();
+    expect(mocks.prepare).toHaveBeenCalledTimes(1);
     expect(mocks.ensureStarted).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.prepare.mock.invocationCallOrder[0]
+    ).toBeLessThan(mocks.ensureStarted.mock.invocationCallOrder[0]);
     expect(mocks.dispose).toHaveBeenCalledTimes(1);
   });
 
@@ -168,6 +171,7 @@ describe('iOS XCTest agent runner integration', () => {
     );
 
     expect(mocks.createXCTestAgentController).not.toHaveBeenCalled();
+    expect(mocks.prepare).not.toHaveBeenCalled();
     expect(mocks.ensureStarted).not.toHaveBeenCalled();
   });
 });

--- a/packages/platform-ios/src/instance.ts
+++ b/packages/platform-ios/src/instance.ts
@@ -74,6 +74,33 @@ export const getAppleSimulatorPlatformInstance = async (
     throw new DeviceNotFoundError(getDeviceName(config.device));
   }
 
+  const xctestAgent = permissionsEnabled
+    ? createXCTestAgentController({
+        appBundleId: config.bundleId,
+        target: {
+          kind: 'simulator',
+          id: udid,
+        },
+        capabilities: [createPermissionPromptAutoAcceptCapability()],
+        signal: init.signal,
+      })
+    : null;
+
+  // The XCTest agent build (build-for-testing, destination
+  // "generic/platform=iOS Simulator") does not need a booted device, so
+  // kick it off now to overlap with the boot/waitForBoot sequence below.
+  // It is awaited (not raced) inside the try block further down so build
+  // errors are still surfaced; the .catch here only prevents an
+  // unhandled-rejection warning if boot fails first and this promise is
+  // left to settle unobserved in the meantime.
+  const preparePromise = xctestAgent?.prepare();
+  preparePromise?.catch((error: unknown) => {
+    iosInstanceLogger.debug(
+      'XCTest agent prepare failed while overlapping with simulator boot (surfaced later): %s',
+      error
+    );
+  });
+
   const simulatorStatus = await simctl.getSimulatorStatus(udid);
   let startedByHarness = false;
 
@@ -127,20 +154,9 @@ export const getAppleSimulatorPlatformInstance = async (
     `localhost:${harnessConfig.metroPort}`
   );
 
-  const xctestAgent = permissionsEnabled
-    ? createXCTestAgentController({
-        appBundleId: config.bundleId,
-        target: {
-          kind: 'simulator',
-          id: udid,
-        },
-        capabilities: [createPermissionPromptAutoAcceptCapability()],
-        signal: init.signal,
-      })
-    : null;
-
   let agentStarted = false;
   try {
+    await preparePromise;
     await xctestAgent?.ensureStarted();
     agentStarted = true;
   } finally {


### PR DESCRIPTION
## What is this?

On iOS simulator runs with `permissions` enabled, Harness built the XCTest permission agent strictly after the simulator finished booting, even though the build phase never touches the simulator. This serialized two independent, often lengthy operations for no reason—most noticeably on a cold `xcodebuild` cache (e.g. right after an Xcode version bump).

## How does it work?

In `getAppleSimulatorPlatformInstance`, the XCTest agent controller is now constructed as soon as the simulator's udid is known (before boot), and `prepare()` (the build-only phase, `xcodebuild build-for-testing` against `generic/platform=iOS Simulator`) is kicked off immediately without being awaited. The simulator boot/`waitForBoot`/install/harness-JS-override sequence then runs as before, unaffected by the build. Once that sequence finishes, the outstanding `preparePromise` is awaited first (so a build failure still surfaces and fails startup), followed by `ensureStarted()`, which internally re-calls `prepare()`—a no-op since it's idempotent—before launching the agent process against the now-booted device.

This is safe because:
- `prepare()` only depends on the udid, which is already known before boot, and never touches the booted device (the run phase, `test-without-building` against `id=<udid>`, is untouched and still runs after boot).
- `prepare()` is idempotent (`if (prepared) return`), so calling it early and letting `ensureStarted()` call it again is a no-op.
- The build promise is given a `.catch` at creation to avoid an unhandled-rejection warning if boot fails first, while still being `await`ed inside the `try` block so the real error is surfaced and the existing `finally` cleanup (dispose agent, clear the harness JS override, shut down the simulator if Harness booted it) still runs correctly on any failure path.
- When `permissions` is disabled, `xctestAgent` stays `null` and `preparePromise` is `undefined`, so behavior is byte-for-byte unchanged.

`getApplePhysicalDevicePlatformInstance` is untouched—physical device runs don't boot a simulator, so there's nothing to overlap.

## Why is this useful?

The two operations are independent, so running them concurrently removes dead time from Harness startup on simulator runs with permission auto-acceptance enabled. The win is largest on cold build caches, such as right after an Xcode version bump, where the XCTest agent build can take a while and previously ran back-to-back with the simulator boot instead of alongside it.