### PR TITLE
chore: increase playground harness timeout

### DIFF
--- a/apps/playground/rn-harness.config.mjs
+++ b/apps/playground/rn-harness.config.mjs
@@ -114,7 +114,7 @@ export default {
     }),
   ],
   defaultRunner: 'android',
-  platformReadyTimeout: 300000,
+  platformReadyTimeout: 600000,
   bridgeTimeout: 120000,
   testTimeout: 10000,
 


### PR DESCRIPTION
## What is this?

The playground configuration now allows Harness up to 10 minutes for the platform to become ready.

## How does it work?

It raises `platformReadyTimeout` from 300,000 ms to 600,000 ms in the playground Harness configuration.

## Why is this useful?

It gives local and CI playground runs more time to start on slower environments without timing out prematurely.