### PR TITLE
fix: use static Nx output in pre-push hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,7 +11,7 @@ pre-push:
   parallel: true
   commands:
     test:
-      run: pnpm nx affected -t test --base=origin/main --head=HEAD
+      run: pnpm nx affected -t test --base=origin/main --head=HEAD --outputStyle=static
 
     build:
-      run: pnpm nx affected -t build --base=origin/main --head=HEAD
+      run: pnpm nx affected -t build --base=origin/main --head=HEAD --outputStyle=static


### PR DESCRIPTION
## What is this?

Pre-push checks use static Nx output so they do not start the interactive terminal UI under Lefthook.

## How does it work?

The affected test and build commands pass `--outputStyle=static`, which disables Nx's TUI while retaining the same affected-project checks.

## Why is this useful?

Contributors can push without the Nx native pseudo-terminal panic triggered by Lefthook's TTY.