### PR TITLE
chore: exclude local artifacts from published packages

### DIFF
--- a/.nx/version-plans/version-plan-1785770217523.md
+++ b/.nx/version-plans/version-plan-1785770217523.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Published packages exclude test outputs and local build artifacts.

--- a/packages/babel-preset/.npmignore
+++ b/packages/babel-preset/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/bridge/.npmignore
+++ b/packages/bridge/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/bundler-metro/.npmignore
+++ b/packages/bundler-metro/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/cache/.npmignore
+++ b/packages/cache/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/config/.npmignore
+++ b/packages/config/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/coverage-ios/package.json
+++ b/packages/coverage-ios/package.json
@@ -22,6 +22,7 @@
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
+    "!**/*.tsbuildinfo",
     "!**/.*"
   ],
   "peerDependencies": {

--- a/packages/jest/.npmignore
+++ b/packages/jest/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/metro/.npmignore
+++ b/packages/metro/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/platform-android/.npmignore
+++ b/packages/platform-android/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/platform-ios/.npmignore
+++ b/packages/platform-ios/.npmignore
@@ -1,0 +1,7 @@
+.harness/
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo
+xctest-agent/build/
+xctest-agent/**/xcuserdata/

--- a/packages/platform-vega/.npmignore
+++ b/packages/platform-vega/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/platform-web/.npmignore
+++ b/packages/platform-web/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/platforms/.npmignore
+++ b/packages/platforms/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/plugins/.npmignore
+++ b/packages/plugins/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/react-native-harness/.npmignore
+++ b/packages/react-native-harness/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/runtime/.npmignore
+++ b/packages/runtime/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/tools/.npmignore
+++ b/packages/tools/.npmignore
@@ -1,0 +1,4 @@
+**/__tests__/
+**/*.test.*
+**/*.tsbuildinfo
+dist/*.tsbuildinfo

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
+    "!**/*.tsbuildinfo",
     "!**/.*"
   ],
   "exports": {


### PR DESCRIPTION
## What is this?

Published packages now leave local test output and build artifacts out of their npm tarballs. This prevents the Apple platform package from packaging Xcode build products, simulator caches, and Harness logs.

## How does it work?

Package-level ignore rules exclude tests and TypeScript build caches from public packages. The Apple package also excludes local Harness logs, Xcode build output, and Xcode user state while retaining the XCTest project sources. The existing native-package allowlists now exclude nested TypeScript build-info files. A patch release plan covers the corrected archives.

## Why is this useful?

The Apple platform archive falls from 100.3 MB to 296 KB, so publishing no longer spends time compressing and uploading local Xcode artifacts. Consumers receive only package files needed to use Harness.
