### PR TITLE
fix(runtime): track native Promise instances

### DIFF
--- a/.nx/version-plans/version-plan-1785777985382.md
+++ b/.nx/version-plans/version-plan-1785777985382.md
@@ -2,4 +2,4 @@
 __default__: patch
 ---
 
-Harness preserves native Promise static-method behavior so native-module promises return their settled values on Hermes.
+Harness tracks pending work while preserving native Promise instances so native modules return their settled values on Hermes.

--- a/.nx/version-plans/version-plan-1785777985382.md
+++ b/.nx/version-plans/version-plan-1785777985382.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Harness preserves native Promise static-method behavior so native-module promises return their settled values on Hermes.

--- a/packages/runtime/src/__tests__/promise-tracker.test.ts
+++ b/packages/runtime/src/__tests__/promise-tracker.test.ts
@@ -43,6 +43,74 @@ describe('promise tracker', () => {
     expect(getPendingPromises()).toHaveLength(0);
   });
 
+  it('preserves native Promise static method behavior', async () => {
+    const NativePromise = globalThis.Promise;
+    installPromiseTracker();
+
+    const resolvedValue = Promise.resolve(55);
+    const resolvedUndefined = Promise.resolve();
+    const rejected = Promise.reject('failed');
+    const all = Promise.all([55]);
+    const allSettled = Promise.allSettled([55]);
+    const any = Promise.any([55]);
+    const race = Promise.race([55]);
+    const nativeWithResolvers: unknown = Reflect.get(
+      NativePromise,
+      'withResolvers',
+    );
+    const trackedWithResolvers: unknown = Reflect.get(
+      Promise,
+      'withResolvers',
+    );
+    const withResolvers =
+      typeof nativeWithResolvers === 'function' &&
+      typeof trackedWithResolvers === 'function'
+        ? (Reflect.apply(trackedWithResolvers, Promise, []) as {
+            promise: Promise<number>;
+            resolve: (value: number) => void;
+          })
+        : null;
+    const nativeTry: unknown = Reflect.get(NativePromise, 'try');
+    const trackedTry: unknown = Reflect.get(Promise, 'try');
+    const tried =
+      typeof nativeTry === 'function' && typeof trackedTry === 'function'
+        ? (Reflect.apply(trackedTry, Promise, [() => 55]) as Promise<number>)
+        : null;
+    const rejectedAssertion = expect(rejected).rejects.toBe('failed');
+
+    for (const promise of [
+      resolvedValue,
+      resolvedUndefined,
+      rejected,
+      all,
+      allSettled,
+      any,
+      race,
+      ...(withResolvers ? [withResolvers.promise] : []),
+      ...(tried ? [tried] : []),
+    ]) {
+      expect(Object.getPrototypeOf(promise)).toBe(NativePromise.prototype);
+    }
+
+    withResolvers?.resolve(55);
+
+    await expect(resolvedValue).resolves.toBe(55);
+    await expect(resolvedUndefined).resolves.toBeUndefined();
+    await rejectedAssertion;
+    await expect(all).resolves.toEqual([55]);
+    await expect(allSettled).resolves.toEqual([
+      { status: 'fulfilled', value: 55 },
+    ]);
+    await expect(any).resolves.toBe(55);
+    await expect(race).resolves.toBe(55);
+    if (withResolvers) {
+      await expect(withResolvers.promise).resolves.toBe(55);
+    }
+    if (tried) {
+      await expect(tried).resolves.toBe(55);
+    }
+  });
+
   it('keeps promises pending while their resolved thenable is pending', () => {
     installPromiseTracker();
 

--- a/packages/runtime/src/__tests__/promise-tracker.test.ts
+++ b/packages/runtime/src/__tests__/promise-tracker.test.ts
@@ -35,6 +35,49 @@ describe('promise tracker', () => {
     expect(pending[0].stack).toContain('Promise created');
   });
 
+  it('preserves native Promise instances created through the global constructor', () => {
+    const NativePromise = globalThis.Promise;
+    installPromiseTracker();
+
+    const promise = new Promise(() => undefined);
+
+    expect(Object.getPrototypeOf(promise)).toBe(NativePromise.prototype);
+    expect(promise).toBeInstanceOf(Promise);
+    expect(promise.constructor).toBe(Promise);
+    expect(Promise.resolve(promise)).toBe(promise);
+    expect(Object.keys(promise)).toEqual([]);
+  });
+
+  it('preserves custom Promise subclass behavior', async () => {
+    installPromiseTracker();
+
+    let usedCustomThen = false;
+    class CustomPromise<T> extends Promise<T> {
+      override then<TResult1 = T, TResult2 = never>(
+        onfulfilled?:
+          | ((value: T) => TResult1 | PromiseLike<TResult1>)
+          | undefined
+          | null,
+        onrejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | undefined
+          | null,
+      ): Promise<TResult1 | TResult2> {
+        usedCustomThen = true;
+        return super.then(onfulfilled, onrejected);
+      }
+    }
+
+    const promise = new CustomPromise<number>((resolve) => resolve(55));
+
+    expect(Object.getPrototypeOf(promise)).toBe(CustomPromise.prototype);
+    expect(promise).toBeInstanceOf(CustomPromise);
+    expect(promise.constructor).toBe(CustomPromise);
+    expect(CustomPromise.resolve(promise)).toBe(promise);
+    await expect(promise.then((value) => value)).resolves.toBe(55);
+    expect(usedCustomThen).toBe(true);
+  });
+
   it('removes promises when they resolve', async () => {
     installPromiseTracker();
 

--- a/packages/runtime/src/__tests__/promise-tracker.test.ts
+++ b/packages/runtime/src/__tests__/promise-tracker.test.ts
@@ -154,6 +154,18 @@ describe('promise tracker', () => {
     }
   });
 
+  it('resolves values when Promise.resolve is invoked without a receiver', async () => {
+    installPromiseTracker();
+
+    const resolve = Promise.resolve;
+
+    await expect(Reflect.apply(resolve, undefined, [55])).resolves.toBe(55);
+    await expect(Reflect.apply(resolve, undefined, [])).resolves.toBeUndefined();
+    await expect(
+      Reflect.apply(resolve, undefined, [undefined]),
+    ).resolves.toBeUndefined();
+  });
+
   it('keeps promises pending while their resolved thenable is pending', () => {
     installPromiseTracker();
 

--- a/packages/runtime/src/promise-tracker.ts
+++ b/packages/runtime/src/promise-tracker.ts
@@ -211,11 +211,7 @@ const createTrackedPromiseConstructor = (): PromiseConstructor => {
         )
       ) as Promise<TResult1 | TResult2>;
 
-      if (context && typeof result === 'object') {
-        promiseContexts.set(result, context);
-      }
-
-      return result;
+      return propagatePromiseContext(result, context);
     }
 
     override catch<TResult = never>(
@@ -229,11 +225,7 @@ const createTrackedPromiseConstructor = (): PromiseConstructor => {
         super.catch(wrapPromiseCallback(context, onrejected))
       ) as Promise<T | TResult>;
 
-      if (context && typeof result === 'object') {
-        promiseContexts.set(result, context);
-      }
-
-      return result;
+      return propagatePromiseContext(result, context);
     }
 
     override finally(onfinally?: (() => void) | undefined | null): Promise<T> {
@@ -262,6 +254,92 @@ const createTrackedPromiseConstructor = (): PromiseConstructor => {
         }
       );
     }
+  }
+
+  // Keep static Promise factories on Hermes' native Promise path. Inheriting
+  // these methods makes them construct TrackedPromise instances, which can
+  // expose Hermes' internal promise state instead of the settled value.
+  const nativePromiseMethods = [
+    'resolve',
+    'reject',
+    'all',
+    'allSettled',
+    'any',
+    'race',
+    'try',
+  ] as const;
+
+  for (const methodName of nativePromiseMethods) {
+    const method: unknown = Reflect.get(NativePromise, methodName);
+
+    if (typeof method !== 'function') {
+      continue;
+    }
+
+    Object.defineProperty(TrackedPromise, methodName, {
+      configurable: true,
+      writable: true,
+      value: (...args: unknown[]) =>
+        propagatePromiseContext(
+          Reflect.apply(method, NativePromise, args) as Promise<unknown>,
+          getCurrentPromiseContext(),
+        ),
+    });
+  }
+
+  const withResolvers: unknown = Reflect.get(NativePromise, 'withResolvers');
+
+  if (typeof withResolvers === 'function') {
+    Object.defineProperty(TrackedPromise, 'withResolvers', {
+      configurable: true,
+      writable: true,
+      value: () => {
+        const capability = Reflect.apply(withResolvers, NativePromise, []) as {
+          promise: Promise<unknown>;
+        };
+        propagatePromiseContext(
+          capability.promise,
+          getCurrentPromiseContext(),
+        );
+        return capability;
+      },
+    });
+  }
+
+  function propagatePromiseContext<T>(
+    promise: Promise<T>,
+    context: PromiseTrackerTestContext | undefined,
+  ): Promise<T> {
+    if (!context) {
+      return promise;
+    }
+
+    promiseContexts.set(promise, context);
+
+    if (
+      !(promise instanceof TrackedPromise) &&
+      Object.isExtensible(promise)
+    ) {
+      Object.defineProperties(promise, {
+        then: {
+          configurable: true,
+          writable: true,
+          value: TrackedPromise.prototype.then,
+        },
+        catch: {
+          configurable: true,
+          writable: true,
+          value: TrackedPromise.prototype.catch,
+        },
+        finally: {
+          configurable: true,
+          writable: true,
+          value: TrackedPromise.prototype.finally,
+        },
+      });
+    }
+
+    return promise;
   }
 
   return TrackedPromise as PromiseConstructor;

--- a/packages/runtime/src/promise-tracker.ts
+++ b/packages/runtime/src/promise-tracker.ts
@@ -350,7 +350,8 @@ const createTrackedPromiseConstructor = (): PromiseConstructor => {
       }
 
       const wrapper = function (this: unknown, ...args: unknown[]) {
-        const result: unknown = Reflect.apply(value, this, args);
+        const methodReceiver = this == null ? NativePromise : this;
+        const result: unknown = Reflect.apply(value, methodReceiver, args);
         const context = getCurrentPromiseContext();
 
         if (property === 'withResolvers') {

--- a/packages/runtime/src/promise-tracker.ts
+++ b/packages/runtime/src/promise-tracker.ts
@@ -15,10 +15,6 @@ export type TrackedPromiseRecord = {
 
 type PromiseResolve<T> = (value: T | PromiseLike<T>) => void;
 type PromiseReject = (reason?: unknown) => void;
-type PromiseExecutor<T> = (
-  resolve: PromiseResolve<T>,
-  reject: PromiseReject
-) => void;
 
 // Backstop against unbounded growth if GC can't keep up: never-settling
 // promises created in a hot loop would otherwise OOM the heap. Diagnostics only
@@ -151,115 +147,7 @@ const wrapPromiseCallback = <TArgs extends unknown[], TResult>(
 const createTrackedPromiseConstructor = (): PromiseConstructor => {
   const NativePromise = getOriginalPromise();
 
-  class TrackedPromise<T> extends NativePromise<T> {
-    constructor(executor: PromiseExecutor<T>) {
-      const registration = registerPromise();
-
-      super((resolve, reject) => {
-        try {
-          executor(
-            (value: T | PromiseLike<T>) => {
-              if (isThenable(value)) {
-                runWithoutPromiseTracking(() => {
-                  NativePromise.resolve(value).then(
-                    () => markPromiseSettled(registration.id),
-                    () => markPromiseSettled(registration.id)
-                  );
-                });
-              } else {
-                markPromiseSettled(registration.id);
-              }
-
-              resolve(value);
-            },
-            (reason?: unknown) => {
-              markPromiseSettled(registration.id);
-              reject(reason);
-            }
-          );
-        } catch (error) {
-          markPromiseSettled(registration.id);
-          throw error;
-        }
-      });
-
-      if (registration.id !== null) {
-        promiseIds.set(this, registration.id);
-        promiseFinalization?.register(this, registration.id);
-      }
-
-      if (registration.test) {
-        promiseContexts.set(this, registration.test);
-      }
-    }
-
-    override then<TResult1 = T, TResult2 = never>(
-      onfulfilled?:
-        | ((value: T) => TResult1 | PromiseLike<TResult1>)
-        | undefined
-        | null,
-      onrejected?:
-        | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
-        | undefined
-        | null
-    ): Promise<TResult1 | TResult2> {
-      const context = promiseContexts.get(this);
-      const result = runWithoutPromiseTracking(() =>
-        super.then(
-          wrapPromiseCallback(context, onfulfilled),
-          wrapPromiseCallback(context, onrejected)
-        )
-      ) as Promise<TResult1 | TResult2>;
-
-      return propagatePromiseContext(result, context);
-    }
-
-    override catch<TResult = never>(
-      onrejected?:
-        | ((reason: unknown) => TResult | PromiseLike<TResult>)
-        | undefined
-        | null
-    ): Promise<T | TResult> {
-      const context = promiseContexts.get(this);
-      const result = runWithoutPromiseTracking(() =>
-        super.catch(wrapPromiseCallback(context, onrejected))
-      ) as Promise<T | TResult>;
-
-      return propagatePromiseContext(result, context);
-    }
-
-    override finally(onfinally?: (() => void) | undefined | null): Promise<T> {
-      const context = promiseContexts.get(this);
-
-      if (onfinally == null) {
-        return this.then();
-      }
-
-      return this.then(
-        (value) => {
-          const result = runWithPromiseTrackerTestContext(context, onfinally);
-
-          return runWithoutPromiseTracking(() =>
-            NativePromise.resolve(result).then(() => value)
-          );
-        },
-        (reason: unknown) => {
-          const result = runWithPromiseTrackerTestContext(context, onfinally);
-
-          return runWithoutPromiseTracking(() =>
-            NativePromise.resolve(result).then(() => {
-              throw reason;
-            })
-          );
-        }
-      );
-    }
-  }
-
-  // Keep static Promise factories on Hermes' native Promise path. Inheriting
-  // these methods makes them construct TrackedPromise instances, which can
-  // expose Hermes' internal promise state instead of the settled value.
-  const nativePromiseMethods = [
+  const staticPromiseMethods = new Set<PropertyKey>([
     'resolve',
     'reject',
     'all',
@@ -267,82 +155,220 @@ const createTrackedPromiseConstructor = (): PromiseConstructor => {
     'any',
     'race',
     'try',
-  ] as const;
-
-  for (const methodName of nativePromiseMethods) {
-    const method: unknown = Reflect.get(NativePromise, methodName);
-
-    if (typeof method !== 'function') {
-      continue;
-    }
-
-    Object.defineProperty(TrackedPromise, methodName, {
-      configurable: true,
-      writable: true,
-      value: (...args: unknown[]) =>
-        propagatePromiseContext(
-          Reflect.apply(method, NativePromise, args) as Promise<unknown>,
-          getCurrentPromiseContext(),
-        ),
-    });
-  }
-
-  const withResolvers: unknown = Reflect.get(NativePromise, 'withResolvers');
-
-  if (typeof withResolvers === 'function') {
-    Object.defineProperty(TrackedPromise, 'withResolvers', {
-      configurable: true,
-      writable: true,
-      value: () => {
-        const capability = Reflect.apply(withResolvers, NativePromise, []) as {
-          promise: Promise<unknown>;
-        };
-        propagatePromiseContext(
-          capability.promise,
-          getCurrentPromiseContext(),
-        );
-        return capability;
-      },
-    });
-  }
+    'withResolvers',
+  ]);
+  const staticMethodWrappers = new Map<
+    PropertyKey,
+    { method: unknown; wrapper: unknown }
+  >();
 
   function propagatePromiseContext<T>(
     promise: Promise<T>,
     context: PromiseTrackerTestContext | undefined,
+    decorate = false,
   ): Promise<T> {
-    if (!context) {
-      return promise;
+    if (context) {
+      promiseContexts.set(promise, context);
     }
 
-    promiseContexts.set(promise, context);
+    if ((context || decorate) && Object.isExtensible(promise)) {
+      const properties: PropertyDescriptorMap = {};
 
-    if (
-      !(promise instanceof TrackedPromise) &&
-      Object.isExtensible(promise)
-    ) {
-      Object.defineProperties(promise, {
-        then: {
+      if (promise.then === NativePromise.prototype.then) {
+        properties.then = {
           configurable: true,
           writable: true,
-          value: TrackedPromise.prototype.then,
-        },
-        catch: {
+          value: trackedThen,
+        };
+      }
+
+      if (promise.catch === NativePromise.prototype.catch) {
+        properties.catch = {
           configurable: true,
           writable: true,
-          value: TrackedPromise.prototype.catch,
-        },
-        finally: {
+          value: trackedCatch,
+        };
+      }
+
+      if (promise.finally === NativePromise.prototype.finally) {
+        properties.finally = {
           configurable: true,
           writable: true,
-          value: TrackedPromise.prototype.finally,
-        },
-      });
+          value: trackedFinally,
+        };
+      }
+
+      Object.defineProperties(promise, properties);
     }
 
     return promise;
   }
 
-  return TrackedPromise as PromiseConstructor;
+  function trackedThen<T, TResult1 = T, TResult2 = never>(
+    this: Promise<T>,
+    onfulfilled?:
+      | ((value: T) => TResult1 | PromiseLike<TResult1>)
+      | undefined
+      | null,
+    onrejected?:
+      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+      | undefined
+      | null,
+  ): Promise<TResult1 | TResult2> {
+    const context = promiseContexts.get(this);
+    const result = runWithoutPromiseTracking(() =>
+      NativePromise.prototype.then.call(
+        this,
+        wrapPromiseCallback(context, onfulfilled),
+        wrapPromiseCallback(context, onrejected),
+      ),
+    ) as Promise<TResult1 | TResult2>;
+
+    return propagatePromiseContext(result, context, true);
+  }
+
+  function trackedCatch<T, TResult = never>(
+    this: Promise<T>,
+    onrejected?:
+      | ((reason: unknown) => TResult | PromiseLike<TResult>)
+      | undefined
+      | null,
+  ): Promise<T | TResult> {
+    return trackedThen.call(this, undefined, onrejected) as Promise<T | TResult>;
+  }
+
+  function trackedFinally<T>(
+    this: Promise<T>,
+    onfinally?: (() => void) | undefined | null,
+  ): Promise<T> {
+    const context = promiseContexts.get(this);
+
+    if (onfinally == null) {
+      return trackedThen.call(this) as Promise<T>;
+    }
+
+    return trackedThen.call(
+      this,
+      (value: unknown) => {
+        const result = runWithPromiseTrackerTestContext(context, onfinally);
+
+        return runWithoutPromiseTracking(() =>
+          NativePromise.resolve(result).then(() => value as T),
+        );
+      },
+      (reason: unknown) => {
+        const result = runWithPromiseTrackerTestContext(context, onfinally);
+
+        return runWithoutPromiseTracking(() =>
+          NativePromise.resolve(result).then(() => {
+            throw reason;
+          }),
+        );
+      },
+    ) as Promise<T>;
+  }
+
+  const handler: ProxyHandler<PromiseConstructor> = {
+    construct(target, args, newTarget) {
+      const executor = args[0];
+
+      if (typeof executor !== 'function') {
+        return Reflect.construct(target, args, newTarget);
+      }
+
+      const registration = registerPromise();
+      let promise: Promise<unknown>;
+
+      try {
+        promise = Reflect.construct(
+          target,
+          [
+            (resolve: PromiseResolve<unknown>, reject: PromiseReject) => {
+              try {
+                executor(
+                  (value: unknown | PromiseLike<unknown>) => {
+                    if (isThenable(value)) {
+                      runWithoutPromiseTracking(() => {
+                        NativePromise.resolve(value).then(
+                          () => markPromiseSettled(registration.id),
+                          () => markPromiseSettled(registration.id),
+                        );
+                      });
+                    } else {
+                      markPromiseSettled(registration.id);
+                    }
+
+                    resolve(value);
+                  },
+                  (reason?: unknown) => {
+                    markPromiseSettled(registration.id);
+                    reject(reason);
+                  },
+                );
+              } catch (error) {
+                markPromiseSettled(registration.id);
+                throw error;
+              }
+            },
+          ],
+          newTarget,
+        ) as Promise<unknown>;
+      } catch (error) {
+        markPromiseSettled(registration.id);
+        throw error;
+      }
+
+      if (newTarget === TrackedPromise && Object.isExtensible(promise)) {
+        Object.defineProperty(promise, 'constructor', {
+          configurable: true,
+          writable: true,
+          value: TrackedPromise,
+        });
+      }
+
+      if (registration.id !== null) {
+        promiseIds.set(promise, registration.id);
+        promiseFinalization?.register(promise, registration.id);
+      }
+
+      return propagatePromiseContext(promise, registration.test, true);
+    },
+    get(target, property, receiver) {
+      const value: unknown = Reflect.get(target, property, receiver);
+
+      if (
+        receiver !== TrackedPromise ||
+        !staticPromiseMethods.has(property) ||
+        typeof value !== 'function'
+      ) {
+        return value;
+      }
+
+      const cached = staticMethodWrappers.get(property);
+      if (cached?.method === value) {
+        return cached.wrapper;
+      }
+
+      const wrapper = function (this: unknown, ...args: unknown[]) {
+        const result: unknown = Reflect.apply(value, this, args);
+        const context = getCurrentPromiseContext();
+
+        if (property === 'withResolvers') {
+          const capability = result as { promise: Promise<unknown> };
+          propagatePromiseContext(capability.promise, context);
+          return capability;
+        }
+
+        return propagatePromiseContext(result as Promise<unknown>, context);
+      };
+
+      staticMethodWrappers.set(property, { method: value, wrapper });
+      return wrapper;
+    },
+  };
+
+  const TrackedPromise = new Proxy(NativePromise, handler);
+  return TrackedPromise;
 };
 
 export const installPromiseTracker = (): void => {


### PR DESCRIPTION
## What is this?

This fixes a Harness v1.4 regression where enabling promise tracking replaces native Promise instances with subclass instances. On Hermes, that can make immediately settled native-module promises expose internal promise state instead of their resolved value.

## How does it work?

The tracker now wraps the native Promise constructor in a Proxy. Its construction trap records pending work and wraps settlement callbacks while `Reflect.construct` still creates genuine native Promise instances. Static Promise factories are forwarded through stable wrappers so native results retain Harness test context without becoming subclass instances. When native-module JSI code invokes a captured static method without a receiver, the wrapper falls back to the captured native constructor.

The Proxy preserves native prototypes, `instanceof`, constructor identity, `Promise.resolve` identity, and custom Promise subclass behavior. Harness still propagates context through `then`, `catch`, and `finally`, and continues to omit its internal bookkeeping promises from tracking. Regression coverage verifies direct construction, subclassing, and every supported static method. The runtime suite, build, typecheck, lint, version-plan check, and affected-project pre-commit checks pass.

## Why is this useful?

Nitro and other native modules can return immediately fulfilled or rejected promises without Harness changing their values on Hermes. Promise leak diagnostics continue to work without changing the observable prototype of promises created by application or test code.
