### PR TITLE
fix(jest): report skipped tests correctly

### DIFF
--- a/.nx/version-plans/version-plan-1785943295154.md
+++ b/.nx/version-plans/version-plan-1785943295154.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Skipped tests now appear as skipped in Jest output and compatible result consumers.

--- a/packages/jest/src/__tests__/execute-run.test.ts
+++ b/packages/jest/src/__tests__/execute-run.test.ts
@@ -418,6 +418,61 @@ describe('executeRun', () => {
       ]);
     });
 
+    it.each([
+      ['it.skip', 'skip', 0],
+      ['context.skip', undefined, 5],
+    ] as const)('reports %s to Jest as pending', async (_label, declarationMode, duration) => {
+      let testRunnerListener:
+        | ((event: TestRunnerTestStartedEvent | TestRunnerTestFinishedEvent) => void)
+        | undefined;
+      const { emitEvent, calls: emittedEvents } = makeEmitEvent();
+      const session = makeSession({
+        onTestRunnerEvent: vi.fn((listener) => {
+          testRunnerListener = listener as typeof testRunnerListener;
+          return () => undefined;
+        }),
+      });
+
+      mockRunHarnessTestFile.mockImplementation(async () => {
+        testRunnerListener?.({
+          type: 'test-started',
+          file: 'example.ts',
+          suite: 'suite',
+          name: 'does not run',
+          ancestorTitles: ['suite'],
+          fullName: 'suite does not run',
+          startedAt: 10,
+          declarationMode,
+        });
+        testRunnerListener?.({
+          type: 'test-finished',
+          file: 'example.ts',
+          suite: 'suite',
+          name: 'does not run',
+          ancestorTitles: ['suite'],
+          fullName: 'suite does not run',
+          startedAt: 10,
+          declarationMode,
+          duration,
+          status: 'skipped',
+        });
+
+        return makeFileRunResult();
+      });
+
+      await executeRun(session, [makeTest()], makeWatcher(), emitEvent, makeGlobalConfig());
+
+      expect(emittedEvents).toContainEqual([
+        'test-case-result',
+        'example.ts',
+        expect.objectContaining({
+          fullName: 'suite does not run',
+          numPassingAsserts: 0,
+          status: 'pending',
+        }),
+      ]);
+    });
+
     it('includes pending promise diagnostics in live test-case failures', async () => {
       let testRunnerListener:
         | ((event: TestRunnerTestStartedEvent | TestRunnerTestFinishedEvent) => void)

--- a/packages/jest/src/__tests__/run.test.ts
+++ b/packages/jest/src/__tests__/run.test.ts
@@ -78,6 +78,11 @@ describe('runHarnessTestFile', () => {
       ...createHarnessResult(),
       tests: [
         {
+          name: 'passes',
+          status: 'passed',
+          duration: 1,
+        },
+        {
           name: 'declaration skip',
           status: 'skipped',
           duration: 0,
@@ -100,6 +105,7 @@ describe('runHarnessTestFile', () => {
 
     expect(jestResult.numPendingTests).toBe(2);
     expect(jestResult.testResults).toEqual([
+      expect.objectContaining({ title: 'passes', status: 'passed' }),
       expect.objectContaining({ title: 'declaration skip', status: 'pending' }),
       expect.objectContaining({ title: 'runtime skip', status: 'pending' }),
     ]);

--- a/packages/jest/src/__tests__/run.test.ts
+++ b/packages/jest/src/__tests__/run.test.ts
@@ -71,4 +71,37 @@ describe('runHarnessTestFile', () => {
       expect.objectContaining({ testTimeout: 15000 }),
     );
   });
+
+  it('reports declaration-time and runtime skips to Jest as pending', async () => {
+    const session = createSession(15000);
+    vi.mocked(session.runTestFile).mockResolvedValue({
+      ...createHarnessResult(),
+      tests: [
+        {
+          name: 'declaration skip',
+          status: 'skipped',
+          duration: 0,
+          declarationMode: 'skip',
+        },
+        {
+          name: 'runtime skip',
+          status: 'skipped',
+          duration: 1,
+        },
+      ],
+    });
+
+    const { jestResult } = await runHarnessTestFile({
+      testPath: '/project/example.harness.ts',
+      session,
+      globalConfig: createGlobalConfig(),
+      projectConfig: createProjectConfig(),
+    });
+
+    expect(jestResult.numPendingTests).toBe(2);
+    expect(jestResult.testResults).toEqual([
+      expect.objectContaining({ title: 'declaration skip', status: 'pending' }),
+      expect.objectContaining({ title: 'runtime skip', status: 'pending' }),
+    ]);
+  });
 });

--- a/packages/jest/src/__tests__/test-file-platform-filter.test.ts
+++ b/packages/jest/src/__tests__/test-file-platform-filter.test.ts
@@ -73,7 +73,7 @@ describe('createPlatformSkippedTestResult', () => {
     expect(result.testResults).toHaveLength(1);
     expect(result.testResults[0]).toEqual(
       expect.objectContaining({
-        status: 'skipped',
+        status: 'pending',
         title: 'swift.ios.harness.ts',
         fullName: 'swift.ios.harness.ts',
       }),

--- a/packages/jest/src/execute-run.ts
+++ b/packages/jest/src/execute-run.ts
@@ -32,6 +32,7 @@ import {
 import { formatHarnessErrorMessage } from './format-harness-error.js';
 import { logger } from '@react-native-harness/tools';
 import { printSummary, writeTraceFile } from './diagnostics/index.js';
+import { toJestStatus } from './toJestStatus.js';
 
 const diagnosticsLogger = logger.child('diagnostics');
 
@@ -109,7 +110,7 @@ const emitHarnessTestFinished = async (
     location,
     numPassingAsserts: event.status === 'passed' ? 1 : 0,
     startedAt: event.startedAt,
-    status: event.status,
+    status: toJestStatus(event.status),
     title: event.name,
   };
 

--- a/packages/jest/src/toJestStatus.ts
+++ b/packages/jest/src/toJestStatus.ts
@@ -1,5 +1,6 @@
 import type { Status } from '@jest/test-result';
 import type { TestResultStatus } from '@react-native-harness/bridge';
 
+// Jest's own runners expose skipped assertions as `pending` to reporters.
 export const toJestStatus = (status: TestResultStatus): Status =>
   status === 'skipped' ? 'pending' : status;

--- a/packages/jest/src/toJestStatus.ts
+++ b/packages/jest/src/toJestStatus.ts
@@ -1,0 +1,5 @@
+import type { Status } from '@jest/test-result';
+import type { TestResultStatus } from '@react-native-harness/bridge';
+
+export const toJestStatus = (status: TestResultStatus): Status =>
+  status === 'skipped' ? 'pending' : status;

--- a/packages/jest/src/toTestResult.ts
+++ b/packages/jest/src/toTestResult.ts
@@ -1,4 +1,6 @@
-import type { Status, TestResult } from '@jest/test-result';
+import type { TestResult } from '@jest/test-result';
+import type { TestResultStatus } from '@react-native-harness/bridge';
+import { toJestStatus } from './toJestStatus.js';
 
 export type Options = {
   stats: {
@@ -17,7 +19,7 @@ export type Options = {
     testPath?: string;
     title?: string;
     fullName?: string;
-    status: Status;
+    status: TestResultStatus;
     location?: {
       column: number;
       line: number;
@@ -75,7 +77,7 @@ const getTestResults = ({
       failureMessages: actualErrorMessage ? [actualErrorMessage] : [],
       fullName: test.fullName || test.testPath || jestTestPath || '',
       numPassingAsserts: test.status === 'passed' ? 1 : 0,
-      status: test.status,
+      status: toJestStatus(test.status),
       title: test.title || '',
       location: test.location,
     };


### PR DESCRIPTION
## What is this?

This fixes skipped Harness tests being rendered as successful tests in Jest's verbose output. Both declaration-time skips (`it.skip`) and runtime skips (`context.skip`) now use Jest's skipped treatment.

## How does it work?

Harness keeps its internal `skipped` status and translates it to Jest's public `pending` assertion status at the Jest adapter boundary. The mapping is applied to both live test-case events and final file results, using Jest's supported result APIs without patching Jest or Vitest.

## Why is this useful?

CI output and Jest-compatible result consumers no longer present skipped tests as passing, making test reports accurate and immediately understandable.
