### PR TITLE
feat: support running the harness on a Windows host

### DIFF
--- a/.nx/version-plans/version-plan-1787953392799.md
+++ b/.nx/version-plans/version-plan-1787953392799.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+The harness now runs on a Windows host and recognizes React Native Windows as a device platform: ESM (`rn-harness.config.mjs`) configs load correctly when the harness process runs on Windows, and an app reporting `Platform.OS === 'windows'` completes the bridge handshake instead of failing with "Unsupported platform".

--- a/packages/bridge/src/shared.ts
+++ b/packages/bridge/src/shared.ts
@@ -113,7 +113,7 @@ export type {
 } from './shared/bundler.js';
 
 export type DeviceDescriptor = {
-  platform: 'ios' | 'android' | 'vega' | 'web';
+  platform: 'ios' | 'android' | 'vega' | 'web' | 'windows';
   manufacturer: string;
   model: string;
   osVersion: string;

--- a/packages/config/src/__tests__/reader.test.ts
+++ b/packages/config/src/__tests__/reader.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { getConfig } from '../reader.js';
+
+const CONFIG_BODY = {
+  entryPoint: './index.js',
+  appRegistryComponentName: 'App',
+  runners: [
+    {
+      name: 'test-runner',
+      config: {},
+      runner: 'test-runner',
+      platformId: 'test-platform',
+    },
+  ],
+};
+
+let projectDir: string;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rn-harness-reader-'));
+});
+
+afterEach(() => {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe('getConfig', () => {
+  it('loads an ESM (.mjs) config via a file:// URL', async () => {
+    // A bare absolute path passed to dynamic import() is rejected on Windows
+    // (ERR_UNSUPPORTED_ESM_URL_SCHEME because `C:` reads as a URL scheme); the
+    // reader must convert it with pathToFileURL first. This exercises that path
+    // on every OS and regression-guards it on Windows.
+    fs.writeFileSync(
+      path.join(projectDir, 'rn-harness.config.mjs'),
+      `export default ${JSON.stringify(CONFIG_BODY)};\n`
+    );
+
+    const { config, projectRoot } = await getConfig(projectDir);
+
+    expect(config.entryPoint).toBe('./index.js');
+    expect(config.runners).toHaveLength(1);
+    expect(projectRoot).toBe(projectDir);
+  });
+
+  it('loads a CommonJS (.js) config', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'rn-harness.config.js'),
+      `module.exports = ${JSON.stringify(CONFIG_BODY)};\n`
+    );
+
+    const { config } = await getConfig(projectDir);
+
+    expect(config.appRegistryComponentName).toBe('App');
+  });
+
+  it('loads a JSON config', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'rn-harness.config.json'),
+      JSON.stringify(CONFIG_BODY)
+    );
+
+    const { config } = await getConfig(projectDir);
+
+    expect(config.entryPoint).toBe('./index.js');
+  });
+
+  it('walks up to a parent directory to find the config', async () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'rn-harness.config.mjs'),
+      `export default ${JSON.stringify(CONFIG_BODY)};\n`
+    );
+    const nested = path.join(projectDir, 'a', 'b');
+    fs.mkdirSync(nested, { recursive: true });
+
+    const { projectRoot } = await getConfig(nested);
+
+    expect(projectRoot).toBe(projectDir);
+  });
+});

--- a/packages/config/src/reader.ts
+++ b/packages/config/src/reader.ts
@@ -6,6 +6,7 @@ import {
 } from './errors.js';
 import path from 'node:path';
 import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 import { ZodError } from 'zod';
 
@@ -28,7 +29,11 @@ const importUp = async (
 
       try {
         if (ext === '.mjs') {
-          rawConfig = await import(filePathWithExt).then(
+          // A dynamic import() of an absolute path only accepts a file:// URL.
+          // On POSIX the bare path happens to work; on Windows it is read as a
+          // URL and `C:` is rejected as an unknown scheme
+          // (ERR_UNSUPPORTED_ESM_URL_SCHEME). pathToFileURL normalizes both.
+          rawConfig = await import(pathToFileURL(filePathWithExt).href).then(
             (module) => module.default
           );
         } else {

--- a/packages/runtime/src/client/getDeviceDescriptor.test.ts
+++ b/packages/runtime/src/client/getDeviceDescriptor.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDeviceDescriptor } from './getDeviceDescriptor.js';
+
+const mocks = vi.hoisted(() => ({
+  Platform: {
+    OS: 'ios' as string,
+    constants: {} as Record<string, unknown>,
+  },
+}));
+
+vi.mock('react-native', () => ({
+  Platform: mocks.Platform,
+}));
+
+beforeEach(() => {
+  mocks.Platform.OS = 'ios';
+  mocks.Platform.constants = {};
+});
+
+describe('getDeviceDescriptor', () => {
+  it('describes an iOS device', () => {
+    mocks.Platform.OS = 'ios';
+    mocks.Platform.constants = { osVersion: '17.4' };
+
+    expect(getDeviceDescriptor()).toEqual({
+      platform: 'ios',
+      manufacturer: 'Apple',
+      model: 'Unknown',
+      osVersion: '17.4',
+    });
+  });
+
+  it('describes an Android device', () => {
+    mocks.Platform.OS = 'android';
+    mocks.Platform.constants = {
+      Manufacturer: 'Google',
+      Model: 'Pixel 8',
+      Release: '14',
+    };
+
+    expect(getDeviceDescriptor()).toEqual({
+      platform: 'android',
+      manufacturer: 'Google',
+      model: 'Pixel 8',
+      osVersion: '14',
+    });
+  });
+
+  it('describes web', () => {
+    mocks.Platform.OS = 'web';
+
+    expect(getDeviceDescriptor()).toEqual({
+      platform: 'web',
+      manufacturer: '',
+      model: '',
+      osVersion: '',
+    });
+  });
+
+  it('maps the kepler OS to the vega platform', () => {
+    mocks.Platform.OS = 'kepler';
+
+    expect(getDeviceDescriptor()).toEqual({
+      platform: 'vega',
+      manufacturer: '',
+      model: '',
+      osVersion: '',
+    });
+  });
+
+  it('describes a Windows device', () => {
+    mocks.Platform.OS = 'windows';
+    mocks.Platform.constants = { osVersion: 10 };
+
+    expect(getDeviceDescriptor()).toEqual({
+      platform: 'windows',
+      manufacturer: '',
+      model: '',
+      osVersion: '10',
+    });
+  });
+
+  it('tolerates a Windows device without an osVersion constant', () => {
+    mocks.Platform.OS = 'windows';
+    mocks.Platform.constants = {};
+
+    expect(getDeviceDescriptor().osVersion).toBe('');
+  });
+
+  it('throws for an unknown platform', () => {
+    mocks.Platform.OS = 'tizen';
+
+    expect(() => getDeviceDescriptor()).toThrow('Unsupported platform');
+  });
+});

--- a/packages/runtime/src/client/getDeviceDescriptor.ts
+++ b/packages/runtime/src/client/getDeviceDescriptor.ts
@@ -11,7 +11,7 @@ const getPlatform = (): Platform | PlatformKeplerStatic => {
 };
 
 export type DeviceDescriptor = {
-  platform: 'ios' | 'android' | 'vega' | 'web';
+  platform: 'ios' | 'android' | 'vega' | 'web' | 'windows';
   manufacturer: string;
   model: string;
   osVersion: string;
@@ -53,6 +53,15 @@ export const getDeviceDescriptor = (): DeviceDescriptor => {
       manufacturer: '',
       model: '',
       osVersion: '',
+    };
+  }
+
+  if (platform.OS === 'windows') {
+    return {
+      platform: 'windows',
+      manufacturer: '',
+      model: '',
+      osVersion: String(platform.constants?.osVersion ?? ''),
     };
   }
 


### PR DESCRIPTION
## What is this?

Two fixes that let the Harness host process and runtime handle React Native
Windows. Neither adds a Windows platform runner yet — they remove the host-side
assumptions that make an RNW app fail before any platform-specific work could
run.

- **`@react-native-harness/config`** — loading an ESM `rn-harness.config.mjs`
  fails on a Windows host. The reader passes a bare absolute path to dynamic
  `import()`, and Node only accepts a `file://` URL there; on Windows the drive
  letter is parsed as a URL scheme and rejected with
  `ERR_UNSUPPORTED_ESM_URL_SCHEME`.
- **`@react-native-harness/runtime` / `@react-native-harness/bridge`** —
  `getDeviceDescriptor()` throws `Unsupported platform` for
  `Platform.OS === 'windows'`, which aborts the bridge handshake during
  `reportReady`.

## How does it work?

- The reader now wraps the resolved config path in `pathToFileURL()` before
  `import()`. This is a no-op-shaped transform on POSIX (`/abs` →
  `file:///abs`), so the path is unchanged in behavior there and simply becomes
  valid on Windows.
- `getDeviceDescriptor()` gains a `windows` branch that reports
  `platform: 'windows'` with an `osVersion` read from `Platform.constants`
  (falling back to `''`), and the `DeviceDescriptor` platform union — declared
  in both `runtime` and `bridge` — includes `'windows'`.

Both packages gain unit coverage: the config reader is exercised loading
`.mjs` / `.js` / `.json` configs and walking up to a parent directory, and
`getDeviceDescriptor` now has a test per platform including `windows`.

## Why is this useful?

RNW is a first-class out-of-tree React Native platform. Today, running Harness
against an RNW app requires patching both of these in `node_modules`. Folding
them in removes the patches and is the smallest first step toward first-class
Windows support; the platform runner, out-of-tree Metro wiring, and CI are
separate follow-ups.

---

Note: the Harness test suite has some pre-existing POSIX-path assumptions in
`@react-native-harness/bundler-metro` tests (e.g. `paths.test.ts` passes a
non-absolute-on-Windows path) that fail when the suite runs on a Windows host.
Those are untouched here and out of scope; CI runs on `ubuntu-latest` and is
unaffected.
